### PR TITLE
#8, #9, #11: Allow for user-defined object as Keycloak constructor

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,7 +1,7 @@
 {
   "presets": [
     [
-      "env",
+      "@babel/env",
       {
         "targets": {
           "browsers": [

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules/
 .idea/
+dist/

--- a/README.md
+++ b/README.md
@@ -84,12 +84,34 @@ You can pass in an object as options to the plugin. The following keys are valid
 |---|---|---|
 | `config`|String &#124; Object|`window.__BASEURL__ + '/config'`
 |`init`|Object|`{onLoad: 'login-required'}`
-|`logout`|Object|`
+|`logout`|Object|
 |`onReady`|Function(keycloak)|
 
 ### config
 
-**String**
+**IMPORTANT NOTE**
+
+Currently, the plugin accepts a config object like this:
+
+```
+{
+  authRealm: String,
+  authUrl: String,
+  authClientId: String,
+  logoutRedirectUri: String
+}
+```
+
+**This will be deprecated in the next major release.**
+
+Thereafter, the config object, either returned from an endpoint (string) or
+set directly (object), must be compatible with the Keycloak JS adapter constructor arguments.
+
+The `logoutRedirectUri` must instead be defined in [`options.logout`](#logout)
+
+See description below.
+ 
+#### String
 
 If this option is a string, the plugin will treat it as an URL and make an HTTP GET request to it.
 
@@ -115,7 +137,7 @@ E.g.
 
 These values will be used as constructor parameters to the official Keycloak adapter.
 
-**Object**
+#### Object
 
 If this option is an object, it will be passed on as constructor parameters for the [Keycloak adapter](https://www.keycloak.org/docs/latest/securing_apps/index.html#javascript-adapter-reference).
 No HTTP GET request is done in this case.

--- a/README.md
+++ b/README.md
@@ -71,7 +71,8 @@ This is actually a new Vue instance and can be used as such. It holds this data:
   createLogoutUrl: Function, // Keycloak createLogoutUrl function
   hasRealmRole: Function,    // Keycloak hasRealmRole function
   hasResourceRole: Function, // Keycloak hasResourceRole function
-  token: String              // Access token
+  token: String,             // The base64 encoded token that can be sent in the Authorization header in requests to services
+  tokenParsed: String        // The parsed token as a JavaScript object
 }
 ```
 
@@ -83,6 +84,7 @@ You can pass in an object as options to the plugin. The following keys are valid
 |---|---|---|
 | `config`|String &#124; Object|`window.__BASEURL__ + '/config'`
 |`init`|Object|`{onLoad: 'login-required'}`
+|`logout`|Object|`
 |`onReady`|Function(keycloak)|
 
 ### config
@@ -96,14 +98,18 @@ this a default place to make a GET request.
 
 If no `window.__BASEURL__` exists, `/config` is used.
 
-The plugin then expects the return value to be an object with the following keys and values:
+The return value from the request is used as constructor parameters for the Keycloak adapter.
+As such, it should be an object with valid keys/values.
+
+[See Keycloak's Javascript adapter reference](https://www.keycloak.org/docs/latest/securing_apps/index.html#javascript-adapter-reference)
+
+E.g. 
 
 ```
 {
-  authRealm: String,
-  authUrl: String,
-  authClientId: String,
-  logoutRedirectUri: String
+  realm: String,
+  url: String,
+  clientId: String
 }
 ```
 
@@ -111,12 +117,16 @@ These values will be used as constructor parameters to the official Keycloak ada
 
 **Object**
 
-If this option is an object, the values will be passed as constructor parameters. The keys must have the same naming
-as above. No HTTP GET request is done in this case.
+If this option is an object, it will be passed on as constructor parameters for the [Keycloak adapter](https://www.keycloak.org/docs/latest/securing_apps/index.html#javascript-adapter-reference).
+No HTTP GET request is done in this case.
 
 ### init
 
 This option is the parameter object for the `Keycloak.init` method.
+
+### logout
+
+This option is the parameter object for the `Keycloak.logout` method.
 
 ### onReady
 

--- a/dist/dsb-vue-keycloak.cjs.js
+++ b/dist/dsb-vue-keycloak.cjs.js
@@ -1,5 +1,111 @@
-/* vue-keycloak-js v1.0.9 */
+/*!
+  * vue-keycloak-js v1.0.9
+  * @license ISC
+  */
 'use strict';
+
+function _typeof(obj) {
+  if (typeof Symbol === "function" && typeof Symbol.iterator === "symbol") {
+    _typeof = function (obj) {
+      return typeof obj;
+    };
+  } else {
+    _typeof = function (obj) {
+      return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj;
+    };
+  }
+
+  return _typeof(obj);
+}
+
+function _defineProperty(obj, key, value) {
+  if (key in obj) {
+    Object.defineProperty(obj, key, {
+      value: value,
+      enumerable: true,
+      configurable: true,
+      writable: true
+    });
+  } else {
+    obj[key] = value;
+  }
+
+  return obj;
+}
+
+function _objectSpread(target) {
+  for (var i = 1; i < arguments.length; i++) {
+    var source = arguments[i] != null ? arguments[i] : {};
+    var ownKeys = Object.keys(source);
+
+    if (typeof Object.getOwnPropertySymbols === 'function') {
+      ownKeys = ownKeys.concat(Object.getOwnPropertySymbols(source).filter(function (sym) {
+        return Object.getOwnPropertyDescriptor(source, sym).enumerable;
+      }));
+    }
+
+    ownKeys.forEach(function (key) {
+      _defineProperty(target, key, source[key]);
+    });
+  }
+
+  return target;
+}
+
+function _objectWithoutPropertiesLoose(source, excluded) {
+  if (source == null) return {};
+  var target = {};
+  var sourceKeys = Object.keys(source);
+  var key, i;
+
+  for (i = 0; i < sourceKeys.length; i++) {
+    key = sourceKeys[i];
+    if (excluded.indexOf(key) >= 0) continue;
+    target[key] = source[key];
+  }
+
+  return target;
+}
+
+function _objectWithoutProperties(source, excluded) {
+  if (source == null) return {};
+
+  var target = _objectWithoutPropertiesLoose(source, excluded);
+
+  var key, i;
+
+  if (Object.getOwnPropertySymbols) {
+    var sourceSymbolKeys = Object.getOwnPropertySymbols(source);
+
+    for (i = 0; i < sourceSymbolKeys.length; i++) {
+      key = sourceSymbolKeys[i];
+      if (excluded.indexOf(key) >= 0) continue;
+      if (!Object.prototype.propertyIsEnumerable.call(source, key)) continue;
+      target[key] = source[key];
+    }
+  }
+
+  return target;
+}
+
+function _toPrimitive(input, hint) {
+  if (typeof input !== "object" || input === null) return input;
+  var prim = input[Symbol.toPrimitive];
+
+  if (prim !== undefined) {
+    var res = prim.call(input, hint || "default");
+    if (typeof res !== "object") return res;
+    throw new TypeError("@@toPrimitive must return a primitive value.");
+  }
+
+  return (hint === "string" ? String : Number)(input);
+}
+
+function _toPropertyKey(arg) {
+  var key = _toPrimitive(arg, "string");
+
+  return typeof key === "symbol" ? key : String(key);
+}
 
 function createCommonjsModule(fn, module) {
 	return module = { exports: {} }, fn(module, module.exports), module.exports;
@@ -23,7 +129,7 @@ var keycloak = createCommonjsModule(function (module) {
  * limitations under the License.
  */
 
-(function( window, undefined ) {
+(function( window, undefined$1 ) {
 
     var Keycloak = function (config) {
         if (!(this instanceof Keycloak)) {
@@ -349,7 +455,7 @@ var keycloak = createCommonjsModule(function (module) {
 
         kc.createAccountUrl = function(options) {
             var realm = getRealmUrl();
-            var url = undefined;
+            var url = undefined$1;
             if (typeof realm !== 'undefined') {
                 url = realm
                 + '/account'
@@ -553,7 +659,7 @@ var keycloak = createCommonjsModule(function (module) {
                     return kc.authServerUrl + '/realms/' + encodeURIComponent(kc.realm);
                 }
             } else {
-            	return undefined;
+            	return undefined$1;
             }
         }
 
@@ -1546,36 +1652,32 @@ var keycloak = createCommonjsModule(function (module) {
         }
     };
 
-    if ( 'object' === "object" && module && 'object' === "object" ) {
+    if ( module && 'object' === "object" ) {
         module.exports = Keycloak;
     } else {
         window.Keycloak = Keycloak;
 
-        if ( typeof undefined === "function" && undefined.amd ) {
-            undefined( "keycloak", [], function () { return Keycloak; } );
+        if ( typeof undefined$1 === "function" && undefined$1.amd ) {
+            undefined$1( "keycloak", [], function () { return Keycloak; } );
         }
     }
 })( window );
 });
 
-var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; };
-
 var installed = false;
-
 var index = {
   install: function install(Vue) {
     var params = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
-
     if (installed) return;
     installed = true;
-
     var defaultParams = {
-      config: window.__BASEURL__ ? window.__BASEURL__ + '/config' : '/config',
-      init: { onLoad: 'login-required' }
+      config: window.__BASEURL__ ? "".concat(window.__BASEURL__, "/config") : '/config',
+      init: {
+        onLoad: 'login-required'
+      }
     };
     var options = Object.assign({}, defaultParams, params);
-    if (assertOptions(options).hasError) throw new Error('Invalid options given: ' + assertOptions(options).error);
-
+    if (assertOptions(options).hasError) throw new Error("Invalid options given: ".concat(assertOptions(options).error));
     var watch = new Vue({
       data: function data() {
         return {
@@ -1584,6 +1686,7 @@ var index = {
           userName: null,
           fullName: null,
           token: null,
+          tokenParsed: null,
           logoutFn: null,
           loginFn: null,
           createLoginUrl: null,
@@ -1605,60 +1708,62 @@ var index = {
 };
 
 function init(config, watch, options) {
-  var keycloak$$1 = keycloak({
-    'realm': config['authRealm'],
-    'url': config['authUrl'],
-    'clientId': config['authClientId']
-  });
-
+  var ctor = sanitizeConfig(config);
+  var keycloak$1 = keycloak(ctor);
   watch.$once('ready', function (cb) {
     cb && cb();
   });
+  keycloak$1.init(options.init);
 
-  keycloak$$1.init(options.init);
-  keycloak$$1.onReady = function (authenticated) {
+  keycloak$1.onReady = function (authenticated) {
     updateWatchVariables(authenticated);
     watch.ready = true;
-    typeof options.onReady === 'function' && watch.$emit('ready', options.onReady.bind(this, keycloak$$1));
+    typeof options.onReady === 'function' && watch.$emit('ready', options.onReady.bind(this, keycloak$1));
   };
-  keycloak$$1.onAuthSuccess = function () {
+
+  keycloak$1.onAuthSuccess = function () {
     // Check token validity every 10 seconds (10 000 ms) and, if necessary, update the token.
     // Refresh token if it's valid for less then 60 seconds
     var updateTokenInterval = setInterval(function () {
-      return keycloak$$1.updateToken(60).error(function () {
-        keycloak$$1.clearToken();
+      return keycloak$1.updateToken(60).error(function () {
+        keycloak$1.clearToken();
       });
     }, 10000);
+
     watch.logoutFn = function () {
       clearInterval(updateTokenInterval);
-      keycloak$$1.logout({
+      keycloak$1.logout(options.logout || {
         'redirectUri': config['logoutRedirectUri']
       });
     };
   };
-  keycloak$$1.onAuthRefreshSuccess = function () {
+
+  keycloak$1.onAuthRefreshSuccess = function () {
     updateWatchVariables(true);
   };
-  keycloak$$1.onAuthRefreshError = function () {
+
+  keycloak$1.onAuthRefreshError = function () {
     console.error('Error while trying to refresh the token');
   };
-  keycloak$$1.onAuthError = function (errorData) {
+
+  keycloak$1.onAuthError = function (errorData) {
     console.error('Error during authentication: ' + JSON.stringify(errorData));
   };
 
   function updateWatchVariables() {
     var isAuthenticated = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : false;
-
     watch.authenticated = isAuthenticated;
-    watch.loginFn = keycloak$$1.login;
-    watch.createLoginUrl = keycloak$$1.createLoginUrl;
-    watch.createLogoutUrl = keycloak$$1.createLogoutUrl;
+    watch.loginFn = keycloak$1.login;
+    watch.createLoginUrl = keycloak$1.createLoginUrl;
+    watch.createLogoutUrl = keycloak$1.createLogoutUrl;
+
     if (isAuthenticated) {
-      watch.hasRealmRole = keycloak$$1.hasRealmRole;
-      watch.hasResourceRole = keycloak$$1.hasResourceRole;
-      watch.token = keycloak$$1.token;
-      watch.userName = keycloak$$1.tokenParsed['preferred_username'];
-      watch.fullName = keycloak$$1.tokenParsed['name'];
+      watch.hasRealmRole = keycloak$1.hasRealmRole;
+      watch.hasResourceRole = keycloak$1.hasResourceRole;
+      watch.token = keycloak$1.token;
+      watch.tokenParsed = keycloak$1.tokenParsed;
+      watch.userName = keycloak$1.tokenParsed['preferred_username'];
+      watch.fullName = keycloak$1.tokenParsed['name'];
     }
   }
 }
@@ -1669,14 +1774,26 @@ function assertOptions(options) {
       onReady = options.onReady;
 
   if (typeof config !== 'string' && !_isObject(config)) {
-    return { hasError: true, error: '\'config\' option must be a string or an object. Found: \'' + config + '\'' };
+    return {
+      hasError: true,
+      error: "'config' option must be a string or an object. Found: '".concat(config, "'")
+    };
   }
+
   if (!_isObject(init) || typeof init.onLoad !== 'string') {
-    return { hasError: true, error: '\'init\' option must be an object with an \'onLoad\' property. Found: \'' + init + '\'' };
+    return {
+      hasError: true,
+      error: "'init' option must be an object with an 'onLoad' property. Found: '".concat(init, "'")
+    };
   }
+
   if (onReady && typeof onReady !== 'function') {
-    return { hasError: true, error: '\'onReady\' option must be a function. Found: \'' + onReady + '\'' };
+    return {
+      hasError: true,
+      error: "'onReady' option must be a function. Found: '".concat(onReady, "'")
+    };
   }
+
   return {
     hasError: false,
     error: null
@@ -1684,7 +1801,7 @@ function assertOptions(options) {
 }
 
 function _isObject(obj) {
-  return obj !== null && (typeof obj === 'undefined' ? 'undefined' : _typeof(obj)) === 'object' && Object.prototype.toString.call(obj) !== '[object Array]';
+  return obj !== null && _typeof(obj) === 'object' && Object.prototype.toString.call(obj) !== '[object Array]';
 }
 
 function getConfig(config) {
@@ -1693,6 +1810,7 @@ function getConfig(config) {
     var xhr = new XMLHttpRequest();
     xhr.open('GET', config);
     xhr.setRequestHeader('Accept', 'application/json');
+
     xhr.onreadystatechange = function () {
       if (xhr.readyState === 4) {
         if (xhr.status === 200) {
@@ -1702,8 +1820,28 @@ function getConfig(config) {
         }
       }
     };
+
     xhr.send();
   });
+}
+
+function sanitizeConfig(config) {
+  var renameProp = function renameProp(oldProp, newProp, _ref) {
+    var old = _ref[oldProp],
+        others = _objectWithoutProperties(_ref, [oldProp].map(_toPropertyKey));
+
+    return _objectSpread(_defineProperty({}, newProp, old), others);
+  };
+
+  return Object.keys(config).reduce(function (previous, key) {
+    if (['authRealm', 'authUrl', 'authClientId'].includes(key)) {
+      var cleaned = key.replace('auth', '');
+      var newKey = cleaned.charAt(0).toLowerCase() + cleaned.slice(1);
+      return renameProp(key, newKey, previous);
+    }
+
+    return previous;
+  }, config);
 }
 
 module.exports = index;

--- a/dist/dsb-vue-keycloak.esm.js
+++ b/dist/dsb-vue-keycloak.esm.js
@@ -1,4 +1,110 @@
-/* vue-keycloak-js v1.0.9 */
+/*!
+  * vue-keycloak-js v1.0.9
+  * @license ISC
+  */
+function _typeof(obj) {
+  if (typeof Symbol === "function" && typeof Symbol.iterator === "symbol") {
+    _typeof = function (obj) {
+      return typeof obj;
+    };
+  } else {
+    _typeof = function (obj) {
+      return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj;
+    };
+  }
+
+  return _typeof(obj);
+}
+
+function _defineProperty(obj, key, value) {
+  if (key in obj) {
+    Object.defineProperty(obj, key, {
+      value: value,
+      enumerable: true,
+      configurable: true,
+      writable: true
+    });
+  } else {
+    obj[key] = value;
+  }
+
+  return obj;
+}
+
+function _objectSpread(target) {
+  for (var i = 1; i < arguments.length; i++) {
+    var source = arguments[i] != null ? arguments[i] : {};
+    var ownKeys = Object.keys(source);
+
+    if (typeof Object.getOwnPropertySymbols === 'function') {
+      ownKeys = ownKeys.concat(Object.getOwnPropertySymbols(source).filter(function (sym) {
+        return Object.getOwnPropertyDescriptor(source, sym).enumerable;
+      }));
+    }
+
+    ownKeys.forEach(function (key) {
+      _defineProperty(target, key, source[key]);
+    });
+  }
+
+  return target;
+}
+
+function _objectWithoutPropertiesLoose(source, excluded) {
+  if (source == null) return {};
+  var target = {};
+  var sourceKeys = Object.keys(source);
+  var key, i;
+
+  for (i = 0; i < sourceKeys.length; i++) {
+    key = sourceKeys[i];
+    if (excluded.indexOf(key) >= 0) continue;
+    target[key] = source[key];
+  }
+
+  return target;
+}
+
+function _objectWithoutProperties(source, excluded) {
+  if (source == null) return {};
+
+  var target = _objectWithoutPropertiesLoose(source, excluded);
+
+  var key, i;
+
+  if (Object.getOwnPropertySymbols) {
+    var sourceSymbolKeys = Object.getOwnPropertySymbols(source);
+
+    for (i = 0; i < sourceSymbolKeys.length; i++) {
+      key = sourceSymbolKeys[i];
+      if (excluded.indexOf(key) >= 0) continue;
+      if (!Object.prototype.propertyIsEnumerable.call(source, key)) continue;
+      target[key] = source[key];
+    }
+  }
+
+  return target;
+}
+
+function _toPrimitive(input, hint) {
+  if (typeof input !== "object" || input === null) return input;
+  var prim = input[Symbol.toPrimitive];
+
+  if (prim !== undefined) {
+    var res = prim.call(input, hint || "default");
+    if (typeof res !== "object") return res;
+    throw new TypeError("@@toPrimitive must return a primitive value.");
+  }
+
+  return (hint === "string" ? String : Number)(input);
+}
+
+function _toPropertyKey(arg) {
+  var key = _toPrimitive(arg, "string");
+
+  return typeof key === "symbol" ? key : String(key);
+}
+
 function createCommonjsModule(fn, module) {
 	return module = { exports: {} }, fn(module, module.exports), module.exports;
 }
@@ -21,7 +127,7 @@ var keycloak = createCommonjsModule(function (module) {
  * limitations under the License.
  */
 
-(function( window, undefined ) {
+(function( window, undefined$1 ) {
 
     var Keycloak = function (config) {
         if (!(this instanceof Keycloak)) {
@@ -347,7 +453,7 @@ var keycloak = createCommonjsModule(function (module) {
 
         kc.createAccountUrl = function(options) {
             var realm = getRealmUrl();
-            var url = undefined;
+            var url = undefined$1;
             if (typeof realm !== 'undefined') {
                 url = realm
                 + '/account'
@@ -551,7 +657,7 @@ var keycloak = createCommonjsModule(function (module) {
                     return kc.authServerUrl + '/realms/' + encodeURIComponent(kc.realm);
                 }
             } else {
-            	return undefined;
+            	return undefined$1;
             }
         }
 
@@ -1544,36 +1650,32 @@ var keycloak = createCommonjsModule(function (module) {
         }
     };
 
-    if ( 'object' === "object" && module && 'object' === "object" ) {
+    if ( module && 'object' === "object" ) {
         module.exports = Keycloak;
     } else {
         window.Keycloak = Keycloak;
 
-        if ( typeof undefined === "function" && undefined.amd ) {
-            undefined( "keycloak", [], function () { return Keycloak; } );
+        if ( typeof undefined$1 === "function" && undefined$1.amd ) {
+            undefined$1( "keycloak", [], function () { return Keycloak; } );
         }
     }
 })( window );
 });
 
-var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; };
-
 var installed = false;
-
 var index = {
   install: function install(Vue) {
     var params = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
-
     if (installed) return;
     installed = true;
-
     var defaultParams = {
-      config: window.__BASEURL__ ? window.__BASEURL__ + '/config' : '/config',
-      init: { onLoad: 'login-required' }
+      config: window.__BASEURL__ ? "".concat(window.__BASEURL__, "/config") : '/config',
+      init: {
+        onLoad: 'login-required'
+      }
     };
     var options = Object.assign({}, defaultParams, params);
-    if (assertOptions(options).hasError) throw new Error('Invalid options given: ' + assertOptions(options).error);
-
+    if (assertOptions(options).hasError) throw new Error("Invalid options given: ".concat(assertOptions(options).error));
     var watch = new Vue({
       data: function data() {
         return {
@@ -1582,6 +1684,7 @@ var index = {
           userName: null,
           fullName: null,
           token: null,
+          tokenParsed: null,
           logoutFn: null,
           loginFn: null,
           createLoginUrl: null,
@@ -1603,60 +1706,62 @@ var index = {
 };
 
 function init(config, watch, options) {
-  var keycloak$$1 = keycloak({
-    'realm': config['authRealm'],
-    'url': config['authUrl'],
-    'clientId': config['authClientId']
-  });
-
+  var ctor = sanitizeConfig(config);
+  var keycloak$1 = keycloak(ctor);
   watch.$once('ready', function (cb) {
     cb && cb();
   });
+  keycloak$1.init(options.init);
 
-  keycloak$$1.init(options.init);
-  keycloak$$1.onReady = function (authenticated) {
+  keycloak$1.onReady = function (authenticated) {
     updateWatchVariables(authenticated);
     watch.ready = true;
-    typeof options.onReady === 'function' && watch.$emit('ready', options.onReady.bind(this, keycloak$$1));
+    typeof options.onReady === 'function' && watch.$emit('ready', options.onReady.bind(this, keycloak$1));
   };
-  keycloak$$1.onAuthSuccess = function () {
+
+  keycloak$1.onAuthSuccess = function () {
     // Check token validity every 10 seconds (10 000 ms) and, if necessary, update the token.
     // Refresh token if it's valid for less then 60 seconds
     var updateTokenInterval = setInterval(function () {
-      return keycloak$$1.updateToken(60).error(function () {
-        keycloak$$1.clearToken();
+      return keycloak$1.updateToken(60).error(function () {
+        keycloak$1.clearToken();
       });
     }, 10000);
+
     watch.logoutFn = function () {
       clearInterval(updateTokenInterval);
-      keycloak$$1.logout({
+      keycloak$1.logout(options.logout || {
         'redirectUri': config['logoutRedirectUri']
       });
     };
   };
-  keycloak$$1.onAuthRefreshSuccess = function () {
+
+  keycloak$1.onAuthRefreshSuccess = function () {
     updateWatchVariables(true);
   };
-  keycloak$$1.onAuthRefreshError = function () {
+
+  keycloak$1.onAuthRefreshError = function () {
     console.error('Error while trying to refresh the token');
   };
-  keycloak$$1.onAuthError = function (errorData) {
+
+  keycloak$1.onAuthError = function (errorData) {
     console.error('Error during authentication: ' + JSON.stringify(errorData));
   };
 
   function updateWatchVariables() {
     var isAuthenticated = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : false;
-
     watch.authenticated = isAuthenticated;
-    watch.loginFn = keycloak$$1.login;
-    watch.createLoginUrl = keycloak$$1.createLoginUrl;
-    watch.createLogoutUrl = keycloak$$1.createLogoutUrl;
+    watch.loginFn = keycloak$1.login;
+    watch.createLoginUrl = keycloak$1.createLoginUrl;
+    watch.createLogoutUrl = keycloak$1.createLogoutUrl;
+
     if (isAuthenticated) {
-      watch.hasRealmRole = keycloak$$1.hasRealmRole;
-      watch.hasResourceRole = keycloak$$1.hasResourceRole;
-      watch.token = keycloak$$1.token;
-      watch.userName = keycloak$$1.tokenParsed['preferred_username'];
-      watch.fullName = keycloak$$1.tokenParsed['name'];
+      watch.hasRealmRole = keycloak$1.hasRealmRole;
+      watch.hasResourceRole = keycloak$1.hasResourceRole;
+      watch.token = keycloak$1.token;
+      watch.tokenParsed = keycloak$1.tokenParsed;
+      watch.userName = keycloak$1.tokenParsed['preferred_username'];
+      watch.fullName = keycloak$1.tokenParsed['name'];
     }
   }
 }
@@ -1667,14 +1772,26 @@ function assertOptions(options) {
       onReady = options.onReady;
 
   if (typeof config !== 'string' && !_isObject(config)) {
-    return { hasError: true, error: '\'config\' option must be a string or an object. Found: \'' + config + '\'' };
+    return {
+      hasError: true,
+      error: "'config' option must be a string or an object. Found: '".concat(config, "'")
+    };
   }
+
   if (!_isObject(init) || typeof init.onLoad !== 'string') {
-    return { hasError: true, error: '\'init\' option must be an object with an \'onLoad\' property. Found: \'' + init + '\'' };
+    return {
+      hasError: true,
+      error: "'init' option must be an object with an 'onLoad' property. Found: '".concat(init, "'")
+    };
   }
+
   if (onReady && typeof onReady !== 'function') {
-    return { hasError: true, error: '\'onReady\' option must be a function. Found: \'' + onReady + '\'' };
+    return {
+      hasError: true,
+      error: "'onReady' option must be a function. Found: '".concat(onReady, "'")
+    };
   }
+
   return {
     hasError: false,
     error: null
@@ -1682,7 +1799,7 @@ function assertOptions(options) {
 }
 
 function _isObject(obj) {
-  return obj !== null && (typeof obj === 'undefined' ? 'undefined' : _typeof(obj)) === 'object' && Object.prototype.toString.call(obj) !== '[object Array]';
+  return obj !== null && _typeof(obj) === 'object' && Object.prototype.toString.call(obj) !== '[object Array]';
 }
 
 function getConfig(config) {
@@ -1691,6 +1808,7 @@ function getConfig(config) {
     var xhr = new XMLHttpRequest();
     xhr.open('GET', config);
     xhr.setRequestHeader('Accept', 'application/json');
+
     xhr.onreadystatechange = function () {
       if (xhr.readyState === 4) {
         if (xhr.status === 200) {
@@ -1700,8 +1818,28 @@ function getConfig(config) {
         }
       }
     };
+
     xhr.send();
   });
+}
+
+function sanitizeConfig(config) {
+  var renameProp = function renameProp(oldProp, newProp, _ref) {
+    var old = _ref[oldProp],
+        others = _objectWithoutProperties(_ref, [oldProp].map(_toPropertyKey));
+
+    return _objectSpread(_defineProperty({}, newProp, old), others);
+  };
+
+  return Object.keys(config).reduce(function (previous, key) {
+    if (['authRealm', 'authUrl', 'authClientId'].includes(key)) {
+      var cleaned = key.replace('auth', '');
+      var newKey = cleaned.charAt(0).toLowerCase() + cleaned.slice(1);
+      return renameProp(key, newKey, previous);
+    }
+
+    return previous;
+  }, config);
 }
 
 export default index;

--- a/dist/dsb-vue-keycloak.umd.js
+++ b/dist/dsb-vue-keycloak.umd.js
@@ -1,1715 +1,1853 @@
-/* vue-keycloak-js v1.0.9 */
+/*!
+  * vue-keycloak-js v1.0.9
+  * @license ISC
+  */
 (function (global, factory) {
-	typeof exports === 'object' && typeof module !== 'undefined' ? module.exports = factory() :
-	typeof define === 'function' && define.amd ? define(factory) :
-	(global['dsb-vue-keycloak'] = factory());
-}(this, (function () { 'use strict';
-
-function createCommonjsModule(fn, module) {
-	return module = { exports: {} }, fn(module, module.exports), module.exports;
-}
-
-var keycloak = createCommonjsModule(function (module) {
-/*
- * Copyright 2016 Red Hat, Inc. and/or its affiliates
- * and other contributors as indicated by the @author tags.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
-(function( window, undefined ) {
-
-    var Keycloak = function (config) {
-        if (!(this instanceof Keycloak)) {
-            return new Keycloak(config);
-        }
-
-        var kc = this;
-        var adapter;
-        var refreshQueue = [];
-        var callbackStorage;
-
-        var loginIframe = {
-            enable: true,
-            callbackList: [],
-            interval: 5
-        };
-
-        var scripts = document.getElementsByTagName('script');
-        for (var i = 0; i < scripts.length; i++) {
-            if ((scripts[i].src.indexOf('keycloak.js') !== -1 || scripts[i].src.indexOf('keycloak.min.js') !== -1) && scripts[i].src.indexOf('version=') !== -1) {
-                kc.iframeVersion = scripts[i].src.substring(scripts[i].src.indexOf('version=') + 8).split('&')[0];
-            }
-        }
-
-        var useNonce = true;
-        
-        kc.init = function (initOptions) {
-            kc.authenticated = false;
-
-            callbackStorage = createCallbackStorage();
-            var adapters = ['default', 'cordova', 'cordova-native'];
-
-            if (initOptions && adapters.indexOf(initOptions.adapter) > -1) {
-                adapter = loadAdapter(initOptions.adapter);
-            } else if (initOptions && typeof initOptions.adapter === "object") {
-                adapter = initOptions.adapter;
-            } else {
-                if (window.Cordova || window.cordova) {
-                    adapter = loadAdapter('cordova');
-                } else {
-                    adapter = loadAdapter();
-                }
-            }
-
-            if (initOptions) {
-                if (typeof initOptions.useNonce !== 'undefined') {
-                    useNonce = initOptions.useNonce;
-                }
-
-                if (typeof initOptions.checkLoginIframe !== 'undefined') {
-                    loginIframe.enable = initOptions.checkLoginIframe;
-                }
-
-                if (initOptions.checkLoginIframeInterval) {
-                    loginIframe.interval = initOptions.checkLoginIframeInterval;
-                }
-
-                if (initOptions.promiseType === 'native') {
-                    kc.useNativePromise = typeof Promise === "function";
-                } else {
-                    kc.useNativePromise = false;
-                }
-
-                if (initOptions.onLoad === 'login-required') {
-                    kc.loginRequired = true;
-                }
-
-                if (initOptions.responseMode) {
-                    if (initOptions.responseMode === 'query' || initOptions.responseMode === 'fragment') {
-                        kc.responseMode = initOptions.responseMode;
-                    } else {
-                        throw 'Invalid value for responseMode';
-                    }
-                }
-
-                if (initOptions.flow) {
-                    switch (initOptions.flow) {
-                        case 'standard':
-                            kc.responseType = 'code';
-                            break;
-                        case 'implicit':
-                            kc.responseType = 'id_token token';
-                            break;
-                        case 'hybrid':
-                            kc.responseType = 'code id_token token';
-                            break;
-                        default:
-                            throw 'Invalid value for flow';
-                    }
-                    kc.flow = initOptions.flow;
-                }
-
-                if (initOptions.timeSkew != null) {
-                    kc.timeSkew = initOptions.timeSkew;
-                }
-
-                if(initOptions.redirectUri) {
-                    kc.redirectUri = initOptions.redirectUri;
-                }
-            }
-
-            if (!kc.responseMode) {
-                kc.responseMode = 'fragment';
-            }
-            if (!kc.responseType) {
-                kc.responseType = 'code';
-                kc.flow = 'standard';
-            }
-
-            var promise = createPromise(false);
-
-            var initPromise = createPromise(true);
-            initPromise.promise.success(function() {
-                kc.onReady && kc.onReady(kc.authenticated);
-                promise.setSuccess(kc.authenticated);
-            }).error(function(errorData) {
-                promise.setError(errorData);
-            });
-
-            var configPromise = loadConfig(config);
-
-            function onLoad() {
-                var doLogin = function(prompt) {
-                    if (!prompt) {
-                        options.prompt = 'none';
-                    }
-                    kc.login(options).success(function () {
-                        initPromise.setSuccess();
-                    }).error(function () {
-                        initPromise.setError();
-                    });
-                };
-
-                var options = {};
-                switch (initOptions.onLoad) {
-                    case 'check-sso':
-                        if (loginIframe.enable) {
-                            setupCheckLoginIframe().success(function() {
-                                checkLoginIframe().success(function (unchanged) {
-                                    if (!unchanged) {
-                                        doLogin(false);
-                                    } else {
-                                        initPromise.setSuccess();
-                                    }
-                                }).error(function () {
-                                    initPromise.setError();
-                                });
-                            });
-                        } else {
-                            doLogin(false);
-                        }
-                        break;
-                    case 'login-required':
-                        doLogin(true);
-                        break;
-                    default:
-                        throw 'Invalid value for onLoad';
-                }
-            }
-
-            function processInit() {
-                var callback = parseCallback(window.location.href);
-
-                if (callback) {
-                    window.history.replaceState(window.history.state, null, callback.newUrl);
-                }
-
-                if (callback && callback.valid) {
-                    return setupCheckLoginIframe().success(function() {
-                        processCallback(callback, initPromise);
-                    }).error(function (e) {
-                        initPromise.setError();
-                    });
-                } else if (initOptions) {
-                    if (initOptions.token && initOptions.refreshToken) {
-                        setToken(initOptions.token, initOptions.refreshToken, initOptions.idToken);
-
-                        if (loginIframe.enable) {
-                            setupCheckLoginIframe().success(function() {
-                                checkLoginIframe().success(function (unchanged) {
-                                    if (unchanged) {
-                                        kc.onAuthSuccess && kc.onAuthSuccess();
-                                        initPromise.setSuccess();
-                                        scheduleCheckIframe();
-                                    } else {
-                                        initPromise.setSuccess();
-                                    }
-                                }).error(function () {
-                                    initPromise.setError();
-                                });
-                            });
-                        } else {
-                            kc.updateToken(-1).success(function() {
-                                kc.onAuthSuccess && kc.onAuthSuccess();
-                                initPromise.setSuccess();
-                            }).error(function() {
-                                kc.onAuthError && kc.onAuthError();
-                                if (initOptions.onLoad) {
-                                    onLoad();
-                                } else {
-                                    initPromise.setError();
-                                }
-                            });
-                        }
-                    } else if (initOptions.onLoad) {
-                        onLoad();
-                    } else {
-                        initPromise.setSuccess();
-                    }
-                } else {
-                    initPromise.setSuccess();
-                }
-            }
-
-            configPromise.success(processInit);
-            configPromise.error(function() {
-                promise.setError();
-            });
-
-            return promise.promise;
-        };
-
-        kc.login = function (options) {
-            return adapter.login(options);
-        };
-
-        kc.createLoginUrl = function(options) {
-            var state = createUUID();
-            var nonce = createUUID();
-
-            var redirectUri = adapter.redirectUri(options);
-
-            var callbackState = {
-                state: state,
-                nonce: nonce,
-                redirectUri: encodeURIComponent(redirectUri)
-            };
-
-            if (options && options.prompt) {
-                callbackState.prompt = options.prompt;
-            }
-
-            callbackStorage.add(callbackState);
-
-            var baseUrl;
-            if (options && options.action == 'register') {
-                baseUrl = kc.endpoints.register();
-            } else {
-                baseUrl = kc.endpoints.authorize();
-            }
-
-            var scope;
-            if (options && options.scope) {
-                if (options.scope.indexOf("openid") != -1) {
-                    scope = options.scope;
-                } else {
-                    scope = "openid " + options.scope;
-                }
-            } else {
-                scope = "openid";
-            }
-
-            var url = baseUrl
-                + '?client_id=' + encodeURIComponent(kc.clientId)
-                + '&redirect_uri=' + encodeURIComponent(redirectUri)
-                + '&state=' + encodeURIComponent(state)
-                + '&response_mode=' + encodeURIComponent(kc.responseMode)
-                + '&response_type=' + encodeURIComponent(kc.responseType)
-                + '&scope=' + encodeURIComponent(scope);
-                if (useNonce) {
-                    url = url + '&nonce=' + encodeURIComponent(nonce);
-                }
-
-            if (options && options.prompt) {
-                url += '&prompt=' + encodeURIComponent(options.prompt);
-            }
-
-            if (options && options.maxAge) {
-                url += '&max_age=' + encodeURIComponent(options.maxAge);
-            }
-
-            if (options && options.loginHint) {
-                url += '&login_hint=' + encodeURIComponent(options.loginHint);
-            }
-
-            if (options && options.idpHint) {
-                url += '&kc_idp_hint=' + encodeURIComponent(options.idpHint);
-            }
-
-            if (options && options.locale) {
-                url += '&ui_locales=' + encodeURIComponent(options.locale);
-            }
-            
-            if (options && options.kcLocale) {
-                url += '&kc_locale=' + encodeURIComponent(options.kcLocale);
-            }
-
-            return url;
-        };
-
-        kc.logout = function(options) {
-            return adapter.logout(options);
-        };
-
-        kc.createLogoutUrl = function(options) {
-            var url = kc.endpoints.logout()
-                + '?redirect_uri=' + encodeURIComponent(adapter.redirectUri(options, false));
-
-            return url;
-        };
-
-        kc.register = function (options) {
-            return adapter.register(options);
-        };
-
-        kc.createRegisterUrl = function(options) {
-            if (!options) {
-                options = {};
-            }
-            options.action = 'register';
-            return kc.createLoginUrl(options);
-        };
-
-        kc.createAccountUrl = function(options) {
-            var realm = getRealmUrl();
-            var url = undefined;
-            if (typeof realm !== 'undefined') {
-                url = realm
-                + '/account'
-                + '?referrer=' + encodeURIComponent(kc.clientId)
-                + '&referrer_uri=' + encodeURIComponent(adapter.redirectUri(options));
-            }
-            return url;
-        };
-
-        kc.accountManagement = function() {
-            return adapter.accountManagement();
-        };
-
-        kc.hasRealmRole = function (role) {
-            var access = kc.realmAccess;
-            return !!access && access.roles.indexOf(role) >= 0;
-        };
-
-        kc.hasResourceRole = function(role, resource) {
-            if (!kc.resourceAccess) {
-                return false;
-            }
-
-            var access = kc.resourceAccess[resource || kc.clientId];
-            return !!access && access.roles.indexOf(role) >= 0;
-        };
-
-        kc.loadUserProfile = function() {
-            var url = getRealmUrl() + '/account';
-            var req = new XMLHttpRequest();
-            req.open('GET', url, true);
-            req.setRequestHeader('Accept', 'application/json');
-            req.setRequestHeader('Authorization', 'bearer ' + kc.token);
-
-            var promise = createPromise(false);
-
-            req.onreadystatechange = function () {
-                if (req.readyState == 4) {
-                    if (req.status == 200) {
-                        kc.profile = JSON.parse(req.responseText);
-                        promise.setSuccess(kc.profile);
-                    } else {
-                        promise.setError();
-                    }
-                }
-            };
-
-            req.send();
-
-            return promise.promise;
-        };
-
-        kc.loadUserInfo = function() {
-            var url = kc.endpoints.userinfo();
-            var req = new XMLHttpRequest();
-            req.open('GET', url, true);
-            req.setRequestHeader('Accept', 'application/json');
-            req.setRequestHeader('Authorization', 'bearer ' + kc.token);
-
-            var promise = createPromise(false);
-
-            req.onreadystatechange = function () {
-                if (req.readyState == 4) {
-                    if (req.status == 200) {
-                        kc.userInfo = JSON.parse(req.responseText);
-                        promise.setSuccess(kc.userInfo);
-                    } else {
-                        promise.setError();
-                    }
-                }
-            };
-
-            req.send();
-
-            return promise.promise;
-        };
-
-        kc.isTokenExpired = function(minValidity) {
-            if (!kc.tokenParsed || (!kc.refreshToken && kc.flow != 'implicit' )) {
-                throw 'Not authenticated';
-            }
-
-            if (kc.timeSkew == null) {
-                console.info('[KEYCLOAK] Unable to determine if token is expired as timeskew is not set');
-                return true;
-            }
-
-            var expiresIn = kc.tokenParsed['exp'] - Math.ceil(new Date().getTime() / 1000) + kc.timeSkew;
-            if (minValidity) {
-                expiresIn -= minValidity;
-            }
-            return expiresIn < 0;
-        };
-
-        kc.updateToken = function(minValidity) {
-            var promise = createPromise(false);
-
-            if (!kc.refreshToken) {
-                promise.setError();
-                return promise.promise;
-            }
-
-            minValidity = minValidity || 5;
-
-            var exec = function() {
-                var refreshToken = false;
-                if (minValidity == -1) {
-                    refreshToken = true;
-                    console.info('[KEYCLOAK] Refreshing token: forced refresh');
-                } else if (!kc.tokenParsed || kc.isTokenExpired(minValidity)) {
-                    refreshToken = true;
-                    console.info('[KEYCLOAK] Refreshing token: token expired');
-                }
-
-                if (!refreshToken) {
-                    promise.setSuccess(false);
-                } else {
-                    var params = 'grant_type=refresh_token&' + 'refresh_token=' + kc.refreshToken;
-                    var url = kc.endpoints.token();
-
-                    refreshQueue.push(promise);
-
-                    if (refreshQueue.length == 1) {
-                        var req = new XMLHttpRequest();
-                        req.open('POST', url, true);
-                        req.setRequestHeader('Content-type', 'application/x-www-form-urlencoded');
-                        req.withCredentials = true;
-
-                        if (kc.clientId && kc.clientSecret) {
-                            req.setRequestHeader('Authorization', 'Basic ' + btoa(kc.clientId + ':' + kc.clientSecret));
-                        } else {
-                            params += '&client_id=' + encodeURIComponent(kc.clientId);
-                        }
-
-                        var timeLocal = new Date().getTime();
-
-                        req.onreadystatechange = function () {
-                            if (req.readyState == 4) {
-                                if (req.status == 200) {
-                                    console.info('[KEYCLOAK] Token refreshed');
-
-                                    timeLocal = (timeLocal + new Date().getTime()) / 2;
-
-                                    var tokenResponse = JSON.parse(req.responseText);
-
-                                    setToken(tokenResponse['access_token'], tokenResponse['refresh_token'], tokenResponse['id_token'], timeLocal);
-
-                                    kc.onAuthRefreshSuccess && kc.onAuthRefreshSuccess();
-                                    for (var p = refreshQueue.pop(); p != null; p = refreshQueue.pop()) {
-                                        p.setSuccess(true);
-                                    }
-                                } else {
-                                    console.warn('[KEYCLOAK] Failed to refresh token');
-
-                                    if (req.status == 400) {
-                                        kc.clearToken();
-                                    }
-
-                                    kc.onAuthRefreshError && kc.onAuthRefreshError();
-                                    for (var p = refreshQueue.pop(); p != null; p = refreshQueue.pop()) {
-                                        p.setError(true);
-                                    }
-                                }
-                            }
-                        };
-
-                        req.send(params);
-                    }
-                }
-            };
-
-            if (loginIframe.enable) {
-                var iframePromise = checkLoginIframe();
-                iframePromise.success(function() {
-                    exec();
-                }).error(function() {
-                    promise.setError();
-                });
-            } else {
-                exec();
-            }
-
-            return promise.promise;
-        };
-
-        kc.clearToken = function() {
-            if (kc.token) {
-                setToken(null, null, null);
-                kc.onAuthLogout && kc.onAuthLogout();
-                if (kc.loginRequired) {
-                    kc.login();
-                }
-            }
-        };
-
-        function getRealmUrl() {
-            if (typeof kc.authServerUrl !== 'undefined') {
-                if (kc.authServerUrl.charAt(kc.authServerUrl.length - 1) == '/') {
-                    return kc.authServerUrl + 'realms/' + encodeURIComponent(kc.realm);
-                } else {
-                    return kc.authServerUrl + '/realms/' + encodeURIComponent(kc.realm);
-                }
-            } else {
-            	return undefined;
-            }
-        }
-
-        function getOrigin() {
-            if (!window.location.origin) {
-                return window.location.protocol + "//" + window.location.hostname + (window.location.port ? ':' + window.location.port: '');
-            } else {
-                return window.location.origin;
-            }
-        }
-
-        function processCallback(oauth, promise) {
-            var code = oauth.code;
-            var error = oauth.error;
-            var prompt = oauth.prompt;
-
-            var timeLocal = new Date().getTime();
-
-            if (error) {
-                if (prompt != 'none') {
-                    var errorData = { error: error, error_description: oauth.error_description };
-                    kc.onAuthError && kc.onAuthError(errorData);
-                    promise && promise.setError(errorData);
-                } else {
-                    promise && promise.setSuccess();
-                }
-                return;
-            } else if ((kc.flow != 'standard') && (oauth.access_token || oauth.id_token)) {
-                authSuccess(oauth.access_token, null, oauth.id_token, true);
-            }
-
-            if ((kc.flow != 'implicit') && code) {
-                var params = 'code=' + code + '&grant_type=authorization_code';
-                var url = kc.endpoints.token();
-
-                var req = new XMLHttpRequest();
-                req.open('POST', url, true);
-                req.setRequestHeader('Content-type', 'application/x-www-form-urlencoded');
-
-                if (kc.clientId && kc.clientSecret) {
-                    req.setRequestHeader('Authorization', 'Basic ' + btoa(kc.clientId + ':' + kc.clientSecret));
-                } else {
-                    params += '&client_id=' + encodeURIComponent(kc.clientId);
-                }
-
-                params += '&redirect_uri=' + oauth.redirectUri;
-
-                req.withCredentials = true;
-
-                req.onreadystatechange = function() {
-                    if (req.readyState == 4) {
-                        if (req.status == 200) {
-
-                            var tokenResponse = JSON.parse(req.responseText);
-                            authSuccess(tokenResponse['access_token'], tokenResponse['refresh_token'], tokenResponse['id_token'], kc.flow === 'standard');
-                            scheduleCheckIframe();
-                        } else {
-                            kc.onAuthError && kc.onAuthError();
-                            promise && promise.setError();
-                        }
-                    }
-                };
-
-                req.send(params);
-            }
-
-            function authSuccess(accessToken, refreshToken, idToken, fulfillPromise) {
-                timeLocal = (timeLocal + new Date().getTime()) / 2;
-
-                setToken(accessToken, refreshToken, idToken, timeLocal);
-
-                if (useNonce && ((kc.tokenParsed && kc.tokenParsed.nonce != oauth.storedNonce) ||
-                    (kc.refreshTokenParsed && kc.refreshTokenParsed.nonce != oauth.storedNonce) ||
-                    (kc.idTokenParsed && kc.idTokenParsed.nonce != oauth.storedNonce))) {
-
-                    console.info('[KEYCLOAK] Invalid nonce, clearing token');
-                    kc.clearToken();
-                    promise && promise.setError();
-                } else {
-                    if (fulfillPromise) {
-                        kc.onAuthSuccess && kc.onAuthSuccess();
-                        promise && promise.setSuccess();
-                    }
-                }
-            }
-
-        }
-
-        function loadConfig(url) {
-            var promise = createPromise(true);
-            var configUrl;
-
-            if (!config) {
-                configUrl = 'keycloak.json';
-            } else if (typeof config === 'string') {
-                configUrl = config;
-            }
-
-            function setupOidcEndoints(oidcConfiguration) {
-                if (! oidcConfiguration) {
-                    kc.endpoints = {
-                        authorize: function() {
-                            return getRealmUrl() + '/protocol/openid-connect/auth';
-                        },
-                        token: function() {
-                            return getRealmUrl() + '/protocol/openid-connect/token';
-                        },
-                        logout: function() {
-                            return getRealmUrl() + '/protocol/openid-connect/logout';
-                        },
-                        checkSessionIframe: function() {
-                            var src = getRealmUrl() + '/protocol/openid-connect/login-status-iframe.html';
-                            if (kc.iframeVersion) {
-                              src = src + '?version=' + kc.iframeVersion;
-                            }
-                            return src;
-                        },
-                        register: function() {
-                            return getRealmUrl() + '/protocol/openid-connect/registrations';
-                        },
-                        userinfo: function() {
-                            return getRealmUrl() + '/protocol/openid-connect/userinfo';
-                        }
-                    };
-                } else {
-                    kc.endpoints = {
-                        authorize: function() {
-                            return oidcConfiguration.authorization_endpoint;
-                        },
-                        token: function() {
-                            return oidcConfiguration.token_endpoint;
-                        },
-                        logout: function() {
-                            if (!oidcConfiguration.end_session_endpoint) {
-                                throw "Not supported by the OIDC server";
-                            }
-                            return oidcConfiguration.end_session_endpoint;
-                        },
-                        checkSessionIframe: function() {
-                            if (!oidcConfiguration.check_session_iframe) {
-                                throw "Not supported by the OIDC server";
-                            }
-                            return oidcConfiguration.check_session_iframe;
-                        },
-                        register: function() {
-                            throw 'Redirection to "Register user" page not supported in standard OIDC mode';
-                        },
-                        userinfo: function() {
-                            if (!oidcConfiguration.userinfo_endpoint) {
-                                throw "Not supported by the OIDC server";
-                            }
-                            return oidcConfiguration.userinfo_endpoint;
-                        }
-                    };
-                }
-            }
-
-            if (configUrl) {
-                var req = new XMLHttpRequest();
-                req.open('GET', configUrl, true);
-                req.setRequestHeader('Accept', 'application/json');
-
-                req.onreadystatechange = function () {
-                    if (req.readyState == 4) {
-                        if (req.status == 200 || fileLoaded(req)) {
-                            var config = JSON.parse(req.responseText);
-
-                            kc.authServerUrl = config['auth-server-url'];
-                            kc.realm = config['realm'];
-                            kc.clientId = config['resource'];
-                            kc.clientSecret = (config['credentials'] || {})['secret'];
-                            setupOidcEndoints(null);
-                            promise.setSuccess();
-                        } else {
-                            promise.setError();
-                        }
-                    }
-                };
-
-                req.send();
-            } else {
-                if (!config.clientId) {
-                    throw 'clientId missing';
-                }
-
-                kc.clientId = config.clientId;
-                kc.clientSecret = (config.credentials || {}).secret;
-
-                var oidcProvider = config['oidcProvider'];
-                if (!oidcProvider) {
-                    if (!config['url']) {
-                        var scripts = document.getElementsByTagName('script');
-                        for (var i = 0; i < scripts.length; i++) {
-                            if (scripts[i].src.match(/.*keycloak\.js/)) {
-                                config.url = scripts[i].src.substr(0, scripts[i].src.indexOf('/js/keycloak.js'));
-                                break;
-                            }
-                        }
-                    }
-                    if (!config.realm) {
-                        throw 'realm missing';
-                    }
-
-                    kc.authServerUrl = config.url;
-                    kc.realm = config.realm;
-                    setupOidcEndoints(null);
-                    promise.setSuccess();
-                } else {
-                    if (typeof oidcProvider === 'string') {
-                        var oidcProviderConfigUrl;
-                        if (oidcProvider.charAt(oidcProvider.length - 1) == '/') {
-                            oidcProviderConfigUrl = oidcProvider + '.well-known/openid-configuration';
-                        } else {
-                            oidcProviderConfigUrl = oidcProvider + '/.well-known/openid-configuration';
-                        }
-                        var req = new XMLHttpRequest();
-                        req.open('GET', oidcProviderConfigUrl, true);
-                        req.setRequestHeader('Accept', 'application/json');
-
-                        req.onreadystatechange = function () {
-                            if (req.readyState == 4) {
-                                if (req.status == 200 || fileLoaded(req)) {
-                                    var oidcProviderConfig = JSON.parse(req.responseText);
-                                    setupOidcEndoints(oidcProviderConfig);
-                                    promise.setSuccess();
-                                } else {
-                                    promise.setError();
-                                }
-                            }
-                        };
-
-                        req.send();
-                    } else {
-                        setupOidcEndoints(oidcProvider);
-                        promise.setSuccess();
-                    }
-                }
-            }
-
-            return promise.promise;
-        }
-
-        function fileLoaded(xhr) {
-            return xhr.status == 0 && xhr.responseText && xhr.responseURL.startsWith('file:');
-        }
-
-        function setToken(token, refreshToken, idToken, timeLocal) {
-            if (kc.tokenTimeoutHandle) {
-                clearTimeout(kc.tokenTimeoutHandle);
-                kc.tokenTimeoutHandle = null;
-            }
-
-            if (refreshToken) {
-                kc.refreshToken = refreshToken;
-                kc.refreshTokenParsed = decodeToken(refreshToken);
-            } else {
-                delete kc.refreshToken;
-                delete kc.refreshTokenParsed;
-            }
-
-            if (idToken) {
-                kc.idToken = idToken;
-                kc.idTokenParsed = decodeToken(idToken);
-            } else {
-                delete kc.idToken;
-                delete kc.idTokenParsed;
-            }
-
-            if (token) {
-                kc.token = token;
-                kc.tokenParsed = decodeToken(token);
-                kc.sessionId = kc.tokenParsed.session_state;
-                kc.authenticated = true;
-                kc.subject = kc.tokenParsed.sub;
-                kc.realmAccess = kc.tokenParsed.realm_access;
-                kc.resourceAccess = kc.tokenParsed.resource_access;
-
-                if (timeLocal) {
-                    kc.timeSkew = Math.floor(timeLocal / 1000) - kc.tokenParsed.iat;
-                }
-
-                if (kc.timeSkew != null) {
-                    console.info('[KEYCLOAK] Estimated time difference between browser and server is ' + kc.timeSkew + ' seconds');
-
-                    if (kc.onTokenExpired) {
-                        var expiresIn = (kc.tokenParsed['exp'] - (new Date().getTime() / 1000) + kc.timeSkew) * 1000;
-                        console.info('[KEYCLOAK] Token expires in ' + Math.round(expiresIn / 1000) + ' s');
-                        if (expiresIn <= 0) {
-                            kc.onTokenExpired();
-                        } else {
-                            kc.tokenTimeoutHandle = setTimeout(kc.onTokenExpired, expiresIn);
-                        }
-                    }
-                }
-            } else {
-                delete kc.token;
-                delete kc.tokenParsed;
-                delete kc.subject;
-                delete kc.realmAccess;
-                delete kc.resourceAccess;
-
-                kc.authenticated = false;
-            }
-        }
-
-        function decodeToken(str) {
-            str = str.split('.')[1];
-
-            str = str.replace('/-/g', '+');
-            str = str.replace('/_/g', '/');
-            switch (str.length % 4)
-            {
-                case 0:
-                    break;
-                case 2:
-                    str += '==';
-                    break;
-                case 3:
-                    str += '=';
-                    break;
-                default:
-                    throw 'Invalid token';
-            }
-
-            str = (str + '===').slice(0, str.length + (str.length % 4));
-            str = str.replace(/-/g, '+').replace(/_/g, '/');
-
-            str = decodeURIComponent(escape(atob(str)));
-
-            str = JSON.parse(str);
-            return str;
-        }
-
-        function createUUID() {
-            var s = [];
-            var hexDigits = '0123456789abcdef';
-            for (var i = 0; i < 36; i++) {
-                s[i] = hexDigits.substr(Math.floor(Math.random() * 0x10), 1);
-            }
-            s[14] = '4';
-            s[19] = hexDigits.substr((s[19] & 0x3) | 0x8, 1);
-            s[8] = s[13] = s[18] = s[23] = '-';
-            var uuid = s.join('');
-            return uuid;
-        }
-
-        kc.callback_id = 0;
-
-        function parseCallback(url) {
-            var oauth = parseCallbackUrl(url);
-            if (!oauth) {
-                return;
-            }
-
-            var oauthState = callbackStorage.get(oauth.state);
-
-            if (oauthState) {
-                oauth.valid = true;
-                oauth.redirectUri = oauthState.redirectUri;
-                oauth.storedNonce = oauthState.nonce;
-                oauth.prompt = oauthState.prompt;
-            }
-
-            return oauth;
-        }
-
-        function parseCallbackUrl(url) {
-            var supportedParams;
-            switch (kc.flow) {
-                case 'standard':
-                    supportedParams = ['code', 'state', 'session_state'];
-                    break;
-                case 'implicit':
-                    supportedParams = ['access_token', 'token_type', 'id_token', 'state', 'session_state', 'expires_in'];
-                    break;
-                case 'hybrid':
-                    supportedParams = ['access_token', 'id_token', 'code', 'state', 'session_state'];
-                    break;
-            }
-
-            supportedParams.push('error');
-            supportedParams.push('error_description');
-            supportedParams.push('error_uri');
-
-            var queryIndex = url.indexOf('?');
-            var fragmentIndex = url.indexOf('#');
-
-            var newUrl;
-            var parsed;
-
-            if (kc.responseMode === 'query' && queryIndex !== -1) {
-                newUrl = url.substring(0, queryIndex);
-                parsed = parseCallbackParams(url.substring(queryIndex + 1, fragmentIndex !== -1 ? fragmentIndex : url.length), supportedParams);
-                if (parsed.paramsString !== '') {
-                    newUrl += '?' + parsed.paramsString;
-                }
-                if (fragmentIndex !== -1) {
-                    newUrl += url.substring(fragmentIndex);
-                }
-            } else if (kc.responseMode === 'fragment' && fragmentIndex !== -1) {
-                newUrl = url.substring(0, fragmentIndex);
-                parsed = parseCallbackParams(url.substring(fragmentIndex + 1), supportedParams);
-                if (parsed.paramsString !== '') {
-                    newUrl += '#' + parsed.paramsString;
-                }
-            }
-
-            if (parsed && parsed.oauthParams) {
-                if (kc.flow === 'standard' || kc.flow === 'hybrid') {
-                    if ((parsed.oauthParams.code || parsed.oauthParams.error) && parsed.oauthParams.state) {
-                        parsed.oauthParams.newUrl = newUrl;
-                        return parsed.oauthParams;
-                    }
-                } else if (kc.flow === 'implicit') {
-                    if ((parsed.oauthParams.access_token || parsed.oauthParams.error) && parsed.oauthParams.state) {
-                        parsed.oauthParams.newUrl = newUrl;
-                        return parsed.oauthParams;
-                    }
-                }
-            }
-        }
-
-        function parseCallbackParams(paramsString, supportedParams) {
-            var p = paramsString.split('&');
-            var result = {
-                paramsString: '',
-                oauthParams: {}
-            };
-            for (var i = 0; i < p.length; i++) {
-                var t = p[i].split('=');
-                if (supportedParams.indexOf(t[0]) !== -1) {
-                    result.oauthParams[t[0]] = t[1];
-                } else {
-                    if (result.paramsString !== '') {
-                        result.paramsString += '&';
-                    }
-                    result.paramsString += p[i];
-                }
-            }
-            return result;
-        }
-
-        function createPromise(internal) {
-            if (!internal && kc.useNativePromise) {
-                return createNativePromise();
-            } else {
-                return createLegacyPromise();
-            }
-        }
-
-        function createNativePromise() {
-            // Need to create a native Promise which also preserves the
-            // interface of the custom promise type previously used by the API
-            var p = {
-                setSuccess: function(result) {
-                    p.resolve(result);
-                },
-
-                setError: function(result) {
-                    p.reject(result);
-                }
-            };
-            p.promise = new Promise(function(resolve, reject) {
-                p.resolve = resolve;
-                p.reject = reject;
-            });
-            return p;
-        }
-
-        function createLegacyPromise() {
-            var p = {
-                setSuccess: function(result) {
-                    p.success = true;
-                    p.result = result;
-                    if (p.successCallback) {
-                        p.successCallback(result);
-                    }
-                },
-
-                setError: function(result) {
-                    p.error = true;
-                    p.result = result;
-                    if (p.errorCallback) {
-                        p.errorCallback(result);
-                    }
-                },
-
-                promise: {
-                    success: function(callback) {
-                        if (p.success) {
-                            callback(p.result);
-                        } else if (!p.error) {
-                            p.successCallback = callback;
-                        }
-                        return p.promise;
-                    },
-                    error: function(callback) {
-                        if (p.error) {
-                            callback(p.result);
-                        } else if (!p.success) {
-                            p.errorCallback = callback;
-                        }
-                        return p.promise;
-                    }
-                }
-            };
-            return p;
-        }
-
-        function setupCheckLoginIframe() {
-            var promise = createPromise(true);
-
-            if (!loginIframe.enable) {
-                promise.setSuccess();
-                return promise.promise;
-            }
-
-            if (loginIframe.iframe) {
-                promise.setSuccess();
-                return promise.promise;
-            }
-
-            var iframe = document.createElement('iframe');
-            loginIframe.iframe = iframe;
-
-            iframe.onload = function() {
-                var authUrl = kc.endpoints.authorize();
-                if (authUrl.charAt(0) === '/') {
-                    loginIframe.iframeOrigin = getOrigin();
-                } else {
-                    loginIframe.iframeOrigin = authUrl.substring(0, authUrl.indexOf('/', 8));
-                }
-                promise.setSuccess();
-            };
-
-            var src = kc.endpoints.checkSessionIframe();
-            iframe.setAttribute('src', src );
-            iframe.setAttribute('title', 'keycloak-session-iframe' );
-            iframe.style.display = 'none';
-            document.body.appendChild(iframe);
-
-            var messageCallback = function(event) {
-                if ((event.origin !== loginIframe.iframeOrigin) || (loginIframe.iframe.contentWindow !== event.source)) {
-                    return;
-                }
-
-                if (!(event.data == 'unchanged' || event.data == 'changed' || event.data == 'error')) {
-                    return;
-                }
-
-
-                if (event.data != 'unchanged') {
-                    kc.clearToken();
-                }
-
-                var callbacks = loginIframe.callbackList.splice(0, loginIframe.callbackList.length);
-
-                for (var i = callbacks.length - 1; i >= 0; --i) {
-                    var promise = callbacks[i];
-                    if (event.data == 'error') {
-                        promise.setError();
-                    } else {
-                        promise.setSuccess(event.data == 'unchanged');
-                    }
-                }
-            };
-
-            window.addEventListener('message', messageCallback, false);
-
-            return promise.promise;
-        }
-
-        function scheduleCheckIframe() {
-            if (loginIframe.enable) {
-                if (kc.token) {
-                    setTimeout(function() {
-                        checkLoginIframe().success(function(unchanged) {
-                            if (unchanged) {
-                                scheduleCheckIframe();
-                            }
-                        });
-                    }, loginIframe.interval * 1000);
-                }
-            }
-        }
-
-        function checkLoginIframe() {
-            var promise = createPromise(true);
-
-            if (loginIframe.iframe && loginIframe.iframeOrigin ) {
-                var msg = kc.clientId + ' ' + (kc.sessionId ? kc.sessionId : '');
-                loginIframe.callbackList.push(promise);
-                var origin = loginIframe.iframeOrigin;
-                if (loginIframe.callbackList.length == 1) {
-                    loginIframe.iframe.contentWindow.postMessage(msg, origin);
-                }
-            } else {
-                promise.setSuccess();
-            }
-
-            return promise.promise;
-        }
-
-        function loadAdapter(type) {
-            if (!type || type == 'default') {
-                return {
-                    login: function(options) {
-                        window.location.replace(kc.createLoginUrl(options));
-                        return createPromise().promise;
-                    },
-
-                    logout: function(options) {
-                        window.location.replace(kc.createLogoutUrl(options));
-                        return createPromise().promise;
-                    },
-
-                    register: function(options) {
-                        window.location.replace(kc.createRegisterUrl(options));
-                        return createPromise().promise;
-                    },
-
-                    accountManagement : function() {
-                        var accountUrl = kc.createAccountUrl();
-                        if (typeof accountUrl !== 'undefined') {
-                            window.location.href = accountUrl;
-                        } else {
-                            throw "Not supported by the OIDC server";
-                        }
-                        return createPromise(false).promise;
-                    },
-
-                    redirectUri: function(options, encodeHash) {
-                        if (arguments.length == 1) {
-                            encodeHash = true;
-                        }
-
-                        if (options && options.redirectUri) {
-                            return options.redirectUri;
-                        } else if (kc.redirectUri) {
-                            return kc.redirectUri;
-                        } else {
-                            return location.href;
-                        }
-                    }
-                };
-            }
-
-            if (type == 'cordova') {
-                loginIframe.enable = false;
-                var cordovaOpenWindowWrapper = function(loginUrl, target, options) {
-                    if (window.cordova && window.cordova.InAppBrowser) {
-                        // Use inappbrowser for IOS and Android if available
-                        return window.cordova.InAppBrowser.open(loginUrl, target, options);
-                    } else {
-                        return window.open(loginUrl, target, options);
-                    }
-                };
-
-                var shallowCloneCordovaOptions = function (userOptions) {
-                    if (userOptions && userOptions.cordovaOptions) {
-                        return Object.keys(userOptions.cordovaOptions).reduce(function (options, optionName) {
-                            options[optionName] = userOptions.cordovaOptions[optionName];
-                            return options;
-                        }, {});
-                    } else {
-                        return {};
-                    }
-                };
-
-                var formatCordovaOptions = function (cordovaOptions) {
-                    return Object.keys(cordovaOptions).reduce(function (options, optionName) {
-                        options.push(optionName+"="+cordovaOptions[optionName]);
-                        return options;
-                    }, []).join(",");
-                };
-
-                var createCordovaOptions = function (userOptions) {
-                    var cordovaOptions = shallowCloneCordovaOptions(userOptions);
-                    cordovaOptions.location = 'no';
-                    if (userOptions && userOptions.prompt == 'none') {
-                        cordovaOptions.hidden = 'yes';
-                    }                    
-                    return formatCordovaOptions(cordovaOptions);
-                };
-
-                return {
-                    login: function(options) {
-                        var promise = createPromise(false);
-
-                        var cordovaOptions = createCordovaOptions(options);
-                        var loginUrl = kc.createLoginUrl(options);
-                        var ref = cordovaOpenWindowWrapper(loginUrl, '_blank', cordovaOptions);
-                        var completed = false;
-                        
-                        var closed = false;
-                        var closeBrowser = function() {
-                            closed = true;
-                            ref.close();
-                        };
-
-                        ref.addEventListener('loadstart', function(event) {
-                            if (event.url.indexOf('http://localhost') == 0) {
-                                var callback = parseCallback(event.url);
-                                processCallback(callback, promise);
-                                closeBrowser();
-                                completed = true;
-                            }
-                        });
-
-                        ref.addEventListener('loaderror', function(event) {
-                            if (!completed) {
-                                if (event.url.indexOf('http://localhost') == 0) {
-                                    var callback = parseCallback(event.url);
-                                    processCallback(callback, promise);
-                                    closeBrowser();
-                                    completed = true;
-                                } else {
-                                    promise.setError();
-                                    closeBrowser();
-                                }
-                            }
-                        });
-
-                        ref.addEventListener('exit', function(event) {
-                            if (!closed) {
-                                promise.setError({
-                                    reason: "closed_by_user"
-                                });
-                            }
-                        });
-
-                        return promise.promise;
-                    },
-
-                    logout: function(options) {
-                        var promise = createPromise(false);
-                        
-                        var logoutUrl = kc.createLogoutUrl(options);
-                        var ref = cordovaOpenWindowWrapper(logoutUrl, '_blank', 'location=no,hidden=yes');
-
-                        var error;
-
-                        ref.addEventListener('loadstart', function(event) {
-                            if (event.url.indexOf('http://localhost') == 0) {
-                                ref.close();
-                            }
-                        });
-
-                        ref.addEventListener('loaderror', function(event) {
-                            if (event.url.indexOf('http://localhost') == 0) {
-                                ref.close();
-                            } else {
-                                error = true;
-                                ref.close();
-                            }
-                        });
-
-                        ref.addEventListener('exit', function(event) {
-                            if (error) {
-                                promise.setError();
-                            } else {
-                                kc.clearToken();
-                                promise.setSuccess();
-                            }
-                        });
-
-                        return promise.promise;
-                    },
-
-                    register : function() {
-                        var registerUrl = kc.createRegisterUrl();
-                        var cordovaOptions = createCordovaOptions(options);
-                        var ref = cordovaOpenWindowWrapper(registerUrl, '_blank', cordovaOptions);
-                        ref.addEventListener('loadstart', function(event) {
-                            if (event.url.indexOf('http://localhost') == 0) {
-                                ref.close();
-                            }
-                        });
-                    },
-
-                    accountManagement : function() {
-                        var accountUrl = kc.createAccountUrl();
-                        if (typeof accountUrl !== 'undefined') {
-                            var ref = cordovaOpenWindowWrapper(accountUrl, '_blank', 'location=no');
-                            ref.addEventListener('loadstart', function(event) {
-                                if (event.url.indexOf('http://localhost') == 0) {
-                                    ref.close();
-                                }
-                            });
-                        } else {
-                            throw "Not supported by the OIDC server";
-                        }
-                    },
-
-                    redirectUri: function(options) {
-                        return 'http://localhost';
-                    }
-                }
-            }
-
-            if (type == 'cordova-native') {
-                loginIframe.enable = false;
-
-                return {
-                    login: function(options) {
-                        var promise = createPromise(false);
-                        var loginUrl = kc.createLoginUrl(options);
-
-                        universalLinks.subscribe('keycloak', function(event) {
-                            universalLinks.unsubscribe('keycloak');
-                            window.cordova.plugins.browsertab.close();
-                            var oauth = parseCallback(event.url);
-                            processCallback(oauth, promise);
-                        });
-
-                        window.cordova.plugins.browsertab.openUrl(loginUrl);
-                        return promise.promise;
-                    },
-
-                    logout: function(options) {
-                        var promise = createPromise(false);
-                        var logoutUrl = kc.createLogoutUrl(options);
-
-                        universalLinks.subscribe('keycloak', function(event) {
-                            universalLinks.unsubscribe('keycloak');
-                            window.cordova.plugins.browsertab.close();
-                            kc.clearToken();
-                            promise.setSuccess();
-                        });
-
-                        window.cordova.plugins.browsertab.openUrl(logoutUrl);
-                        return promise.promise;
-                    },
-
-                    register : function(options) {
-                        var promise = createPromise(false);
-                        var registerUrl = kc.createRegisterUrl(options);
-                        universalLinks.subscribe('keycloak' , function(event) {
-                            universalLinks.unsubscribe('keycloak');
-                            window.cordova.plugins.browsertab.close();
-                            var oauth = parseCallback(event.url);
-                            processCallback(oauth, promise);
-                        });
-                        window.cordova.plugins.browsertab.openUrl(registerUrl);
-                        return promise.promise;
-
-                    },
-
-                    accountManagement : function() {
-                        var accountUrl = kc.createAccountUrl();
-                        if (typeof accountUrl !== 'undefined') {
-                            window.cordova.plugins.browsertab.openUrl(accountUrl);
-                        } else {
-                            throw "Not supported by the OIDC server";
-                        }
-                    },
-
-                    redirectUri: function(options) {
-                        if (options && options.redirectUri) {
-                            return options.redirectUri;
-                        } else if (kc.redirectUri) {
-                            return kc.redirectUri;
-                        } else {
-                            return "http://localhost";
-                        }
-                    }
-                }
-            }
-
-            throw 'invalid adapter type: ' + type;
-        }
-
-        var LocalStorage = function() {
-            if (!(this instanceof LocalStorage)) {
-                return new LocalStorage();
-            }
-
-            localStorage.setItem('kc-test', 'test');
-            localStorage.removeItem('kc-test');
-
-            var cs = this;
-
-            function clearExpired() {
-                var time = new Date().getTime();
-                for (var i = 0; i < localStorage.length; i++)  {
-                    var key = localStorage.key(i);
-                    if (key && key.indexOf('kc-callback-') == 0) {
-                        var value = localStorage.getItem(key);
-                        if (value) {
-                            try {
-                                var expires = JSON.parse(value).expires;
-                                if (!expires || expires < time) {
-                                    localStorage.removeItem(key);
-                                }
-                            } catch (err) {
-                                localStorage.removeItem(key);
-                            }
-                        }
-                    }
-                }
-            }
-
-            cs.get = function(state) {
-                if (!state) {
-                    return;
-                }
-
-                var key = 'kc-callback-' + state;
-                var value = localStorage.getItem(key);
-                if (value) {
-                    localStorage.removeItem(key);
-                    value = JSON.parse(value);
-                }
-
-                clearExpired();
-                return value;
-            };
-
-            cs.add = function(state) {
-                clearExpired();
-
-                var key = 'kc-callback-' + state.state;
-                state.expires = new Date().getTime() + (60 * 60 * 1000);
-                localStorage.setItem(key, JSON.stringify(state));
-            };
-        };
-
-        var CookieStorage = function() {
-            if (!(this instanceof CookieStorage)) {
-                return new CookieStorage();
-            }
-
-            var cs = this;
-
-            cs.get = function(state) {
-                if (!state) {
-                    return;
-                }
-
-                var value = getCookie('kc-callback-' + state);
-                setCookie('kc-callback-' + state, '', cookieExpiration(-100));
-                if (value) {
-                    return JSON.parse(value);
-                }
-            };
-
-            cs.add = function(state) {
-                setCookie('kc-callback-' + state.state, JSON.stringify(state), cookieExpiration(60));
-            };
-
-            cs.removeItem = function(key) {
-                setCookie(key, '', cookieExpiration(-100));
-            };
-
-            var cookieExpiration = function (minutes) {
-                var exp = new Date();
-                exp.setTime(exp.getTime() + (minutes*60*1000));
-                return exp;
-            };
-
-            var getCookie = function (key) {
-                var name = key + '=';
-                var ca = document.cookie.split(';');
-                for (var i = 0; i < ca.length; i++) {
-                    var c = ca[i];
-                    while (c.charAt(0) == ' ') {
-                        c = c.substring(1);
-                    }
-                    if (c.indexOf(name) == 0) {
-                        return c.substring(name.length, c.length);
-                    }
-                }
-                return '';
-            };
-
-            var setCookie = function (key, value, expirationDate) {
-                var cookie = key + '=' + value + '; '
-                    + 'expires=' + expirationDate.toUTCString() + '; ';
-                document.cookie = cookie;
-            };
-        };
-
-        function createCallbackStorage() {
-            try {
-                return new LocalStorage();
-            } catch (err) {
-            }
-
-            return new CookieStorage();
-        }
-    };
-
-    if ( 'object' === "object" && module && 'object' === "object" ) {
-        module.exports = Keycloak;
+  typeof exports === 'object' && typeof module !== 'undefined' ? module.exports = factory() :
+  typeof define === 'function' && define.amd ? define(factory) :
+  (global = global || self, global['dsb-vue-keycloak'] = factory());
+}(this, function () { 'use strict';
+
+  function _typeof(obj) {
+    if (typeof Symbol === "function" && typeof Symbol.iterator === "symbol") {
+      _typeof = function (obj) {
+        return typeof obj;
+      };
     } else {
-        window.Keycloak = Keycloak;
-
-        if ( typeof undefined === "function" && undefined.amd ) {
-            undefined( "keycloak", [], function () { return Keycloak; } );
-        }
+      _typeof = function (obj) {
+        return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj;
+      };
     }
-})( window );
-});
 
-var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; };
+    return _typeof(obj);
+  }
 
-var installed = false;
+  function _defineProperty(obj, key, value) {
+    if (key in obj) {
+      Object.defineProperty(obj, key, {
+        value: value,
+        enumerable: true,
+        configurable: true,
+        writable: true
+      });
+    } else {
+      obj[key] = value;
+    }
 
-var index = {
-  install: function install(Vue) {
-    var params = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
+    return obj;
+  }
 
-    if (installed) return;
-    installed = true;
+  function _objectSpread(target) {
+    for (var i = 1; i < arguments.length; i++) {
+      var source = arguments[i] != null ? arguments[i] : {};
+      var ownKeys = Object.keys(source);
 
-    var defaultParams = {
-      config: window.__BASEURL__ ? window.__BASEURL__ + '/config' : '/config',
-      init: { onLoad: 'login-required' }
-    };
-    var options = Object.assign({}, defaultParams, params);
-    if (assertOptions(options).hasError) throw new Error('Invalid options given: ' + assertOptions(options).error);
-
-    var watch = new Vue({
-      data: function data() {
-        return {
-          ready: false,
-          authenticated: false,
-          userName: null,
-          fullName: null,
-          token: null,
-          logoutFn: null,
-          loginFn: null,
-          createLoginUrl: null,
-          createLogoutUrl: null
-        };
+      if (typeof Object.getOwnPropertySymbols === 'function') {
+        ownKeys = ownKeys.concat(Object.getOwnPropertySymbols(source).filter(function (sym) {
+          return Object.getOwnPropertyDescriptor(source, sym).enumerable;
+        }));
       }
-    });
-    getConfig(options.config).then(function (config) {
-      init(config, watch, options);
-      Object.defineProperty(Vue.prototype, '$keycloak', {
-        get: function get() {
-          return watch;
+
+      ownKeys.forEach(function (key) {
+        _defineProperty(target, key, source[key]);
+      });
+    }
+
+    return target;
+  }
+
+  function _objectWithoutPropertiesLoose(source, excluded) {
+    if (source == null) return {};
+    var target = {};
+    var sourceKeys = Object.keys(source);
+    var key, i;
+
+    for (i = 0; i < sourceKeys.length; i++) {
+      key = sourceKeys[i];
+      if (excluded.indexOf(key) >= 0) continue;
+      target[key] = source[key];
+    }
+
+    return target;
+  }
+
+  function _objectWithoutProperties(source, excluded) {
+    if (source == null) return {};
+
+    var target = _objectWithoutPropertiesLoose(source, excluded);
+
+    var key, i;
+
+    if (Object.getOwnPropertySymbols) {
+      var sourceSymbolKeys = Object.getOwnPropertySymbols(source);
+
+      for (i = 0; i < sourceSymbolKeys.length; i++) {
+        key = sourceSymbolKeys[i];
+        if (excluded.indexOf(key) >= 0) continue;
+        if (!Object.prototype.propertyIsEnumerable.call(source, key)) continue;
+        target[key] = source[key];
+      }
+    }
+
+    return target;
+  }
+
+  function _toPrimitive(input, hint) {
+    if (typeof input !== "object" || input === null) return input;
+    var prim = input[Symbol.toPrimitive];
+
+    if (prim !== undefined) {
+      var res = prim.call(input, hint || "default");
+      if (typeof res !== "object") return res;
+      throw new TypeError("@@toPrimitive must return a primitive value.");
+    }
+
+    return (hint === "string" ? String : Number)(input);
+  }
+
+  function _toPropertyKey(arg) {
+    var key = _toPrimitive(arg, "string");
+
+    return typeof key === "symbol" ? key : String(key);
+  }
+
+  function createCommonjsModule(fn, module) {
+  	return module = { exports: {} }, fn(module, module.exports), module.exports;
+  }
+
+  var keycloak = createCommonjsModule(function (module) {
+  /*
+   * Copyright 2016 Red Hat, Inc. and/or its affiliates
+   * and other contributors as indicated by the @author tags.
+   *
+   * Licensed under the Apache License, Version 2.0 (the "License");
+   * you may not use this file except in compliance with the License.
+   * You may obtain a copy of the License at
+   *
+   * http://www.apache.org/licenses/LICENSE-2.0
+   *
+   * Unless required by applicable law or agreed to in writing, software
+   * distributed under the License is distributed on an "AS IS" BASIS,
+   * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   * See the License for the specific language governing permissions and
+   * limitations under the License.
+   */
+
+  (function( window, undefined$1 ) {
+
+      var Keycloak = function (config) {
+          if (!(this instanceof Keycloak)) {
+              return new Keycloak(config);
+          }
+
+          var kc = this;
+          var adapter;
+          var refreshQueue = [];
+          var callbackStorage;
+
+          var loginIframe = {
+              enable: true,
+              callbackList: [],
+              interval: 5
+          };
+
+          var scripts = document.getElementsByTagName('script');
+          for (var i = 0; i < scripts.length; i++) {
+              if ((scripts[i].src.indexOf('keycloak.js') !== -1 || scripts[i].src.indexOf('keycloak.min.js') !== -1) && scripts[i].src.indexOf('version=') !== -1) {
+                  kc.iframeVersion = scripts[i].src.substring(scripts[i].src.indexOf('version=') + 8).split('&')[0];
+              }
+          }
+
+          var useNonce = true;
+          
+          kc.init = function (initOptions) {
+              kc.authenticated = false;
+
+              callbackStorage = createCallbackStorage();
+              var adapters = ['default', 'cordova', 'cordova-native'];
+
+              if (initOptions && adapters.indexOf(initOptions.adapter) > -1) {
+                  adapter = loadAdapter(initOptions.adapter);
+              } else if (initOptions && typeof initOptions.adapter === "object") {
+                  adapter = initOptions.adapter;
+              } else {
+                  if (window.Cordova || window.cordova) {
+                      adapter = loadAdapter('cordova');
+                  } else {
+                      adapter = loadAdapter();
+                  }
+              }
+
+              if (initOptions) {
+                  if (typeof initOptions.useNonce !== 'undefined') {
+                      useNonce = initOptions.useNonce;
+                  }
+
+                  if (typeof initOptions.checkLoginIframe !== 'undefined') {
+                      loginIframe.enable = initOptions.checkLoginIframe;
+                  }
+
+                  if (initOptions.checkLoginIframeInterval) {
+                      loginIframe.interval = initOptions.checkLoginIframeInterval;
+                  }
+
+                  if (initOptions.promiseType === 'native') {
+                      kc.useNativePromise = typeof Promise === "function";
+                  } else {
+                      kc.useNativePromise = false;
+                  }
+
+                  if (initOptions.onLoad === 'login-required') {
+                      kc.loginRequired = true;
+                  }
+
+                  if (initOptions.responseMode) {
+                      if (initOptions.responseMode === 'query' || initOptions.responseMode === 'fragment') {
+                          kc.responseMode = initOptions.responseMode;
+                      } else {
+                          throw 'Invalid value for responseMode';
+                      }
+                  }
+
+                  if (initOptions.flow) {
+                      switch (initOptions.flow) {
+                          case 'standard':
+                              kc.responseType = 'code';
+                              break;
+                          case 'implicit':
+                              kc.responseType = 'id_token token';
+                              break;
+                          case 'hybrid':
+                              kc.responseType = 'code id_token token';
+                              break;
+                          default:
+                              throw 'Invalid value for flow';
+                      }
+                      kc.flow = initOptions.flow;
+                  }
+
+                  if (initOptions.timeSkew != null) {
+                      kc.timeSkew = initOptions.timeSkew;
+                  }
+
+                  if(initOptions.redirectUri) {
+                      kc.redirectUri = initOptions.redirectUri;
+                  }
+              }
+
+              if (!kc.responseMode) {
+                  kc.responseMode = 'fragment';
+              }
+              if (!kc.responseType) {
+                  kc.responseType = 'code';
+                  kc.flow = 'standard';
+              }
+
+              var promise = createPromise(false);
+
+              var initPromise = createPromise(true);
+              initPromise.promise.success(function() {
+                  kc.onReady && kc.onReady(kc.authenticated);
+                  promise.setSuccess(kc.authenticated);
+              }).error(function(errorData) {
+                  promise.setError(errorData);
+              });
+
+              var configPromise = loadConfig(config);
+
+              function onLoad() {
+                  var doLogin = function(prompt) {
+                      if (!prompt) {
+                          options.prompt = 'none';
+                      }
+                      kc.login(options).success(function () {
+                          initPromise.setSuccess();
+                      }).error(function () {
+                          initPromise.setError();
+                      });
+                  };
+
+                  var options = {};
+                  switch (initOptions.onLoad) {
+                      case 'check-sso':
+                          if (loginIframe.enable) {
+                              setupCheckLoginIframe().success(function() {
+                                  checkLoginIframe().success(function (unchanged) {
+                                      if (!unchanged) {
+                                          doLogin(false);
+                                      } else {
+                                          initPromise.setSuccess();
+                                      }
+                                  }).error(function () {
+                                      initPromise.setError();
+                                  });
+                              });
+                          } else {
+                              doLogin(false);
+                          }
+                          break;
+                      case 'login-required':
+                          doLogin(true);
+                          break;
+                      default:
+                          throw 'Invalid value for onLoad';
+                  }
+              }
+
+              function processInit() {
+                  var callback = parseCallback(window.location.href);
+
+                  if (callback) {
+                      window.history.replaceState(window.history.state, null, callback.newUrl);
+                  }
+
+                  if (callback && callback.valid) {
+                      return setupCheckLoginIframe().success(function() {
+                          processCallback(callback, initPromise);
+                      }).error(function (e) {
+                          initPromise.setError();
+                      });
+                  } else if (initOptions) {
+                      if (initOptions.token && initOptions.refreshToken) {
+                          setToken(initOptions.token, initOptions.refreshToken, initOptions.idToken);
+
+                          if (loginIframe.enable) {
+                              setupCheckLoginIframe().success(function() {
+                                  checkLoginIframe().success(function (unchanged) {
+                                      if (unchanged) {
+                                          kc.onAuthSuccess && kc.onAuthSuccess();
+                                          initPromise.setSuccess();
+                                          scheduleCheckIframe();
+                                      } else {
+                                          initPromise.setSuccess();
+                                      }
+                                  }).error(function () {
+                                      initPromise.setError();
+                                  });
+                              });
+                          } else {
+                              kc.updateToken(-1).success(function() {
+                                  kc.onAuthSuccess && kc.onAuthSuccess();
+                                  initPromise.setSuccess();
+                              }).error(function() {
+                                  kc.onAuthError && kc.onAuthError();
+                                  if (initOptions.onLoad) {
+                                      onLoad();
+                                  } else {
+                                      initPromise.setError();
+                                  }
+                              });
+                          }
+                      } else if (initOptions.onLoad) {
+                          onLoad();
+                      } else {
+                          initPromise.setSuccess();
+                      }
+                  } else {
+                      initPromise.setSuccess();
+                  }
+              }
+
+              configPromise.success(processInit);
+              configPromise.error(function() {
+                  promise.setError();
+              });
+
+              return promise.promise;
+          };
+
+          kc.login = function (options) {
+              return adapter.login(options);
+          };
+
+          kc.createLoginUrl = function(options) {
+              var state = createUUID();
+              var nonce = createUUID();
+
+              var redirectUri = adapter.redirectUri(options);
+
+              var callbackState = {
+                  state: state,
+                  nonce: nonce,
+                  redirectUri: encodeURIComponent(redirectUri)
+              };
+
+              if (options && options.prompt) {
+                  callbackState.prompt = options.prompt;
+              }
+
+              callbackStorage.add(callbackState);
+
+              var baseUrl;
+              if (options && options.action == 'register') {
+                  baseUrl = kc.endpoints.register();
+              } else {
+                  baseUrl = kc.endpoints.authorize();
+              }
+
+              var scope;
+              if (options && options.scope) {
+                  if (options.scope.indexOf("openid") != -1) {
+                      scope = options.scope;
+                  } else {
+                      scope = "openid " + options.scope;
+                  }
+              } else {
+                  scope = "openid";
+              }
+
+              var url = baseUrl
+                  + '?client_id=' + encodeURIComponent(kc.clientId)
+                  + '&redirect_uri=' + encodeURIComponent(redirectUri)
+                  + '&state=' + encodeURIComponent(state)
+                  + '&response_mode=' + encodeURIComponent(kc.responseMode)
+                  + '&response_type=' + encodeURIComponent(kc.responseType)
+                  + '&scope=' + encodeURIComponent(scope);
+                  if (useNonce) {
+                      url = url + '&nonce=' + encodeURIComponent(nonce);
+                  }
+
+              if (options && options.prompt) {
+                  url += '&prompt=' + encodeURIComponent(options.prompt);
+              }
+
+              if (options && options.maxAge) {
+                  url += '&max_age=' + encodeURIComponent(options.maxAge);
+              }
+
+              if (options && options.loginHint) {
+                  url += '&login_hint=' + encodeURIComponent(options.loginHint);
+              }
+
+              if (options && options.idpHint) {
+                  url += '&kc_idp_hint=' + encodeURIComponent(options.idpHint);
+              }
+
+              if (options && options.locale) {
+                  url += '&ui_locales=' + encodeURIComponent(options.locale);
+              }
+              
+              if (options && options.kcLocale) {
+                  url += '&kc_locale=' + encodeURIComponent(options.kcLocale);
+              }
+
+              return url;
+          };
+
+          kc.logout = function(options) {
+              return adapter.logout(options);
+          };
+
+          kc.createLogoutUrl = function(options) {
+              var url = kc.endpoints.logout()
+                  + '?redirect_uri=' + encodeURIComponent(adapter.redirectUri(options, false));
+
+              return url;
+          };
+
+          kc.register = function (options) {
+              return adapter.register(options);
+          };
+
+          kc.createRegisterUrl = function(options) {
+              if (!options) {
+                  options = {};
+              }
+              options.action = 'register';
+              return kc.createLoginUrl(options);
+          };
+
+          kc.createAccountUrl = function(options) {
+              var realm = getRealmUrl();
+              var url = undefined$1;
+              if (typeof realm !== 'undefined') {
+                  url = realm
+                  + '/account'
+                  + '?referrer=' + encodeURIComponent(kc.clientId)
+                  + '&referrer_uri=' + encodeURIComponent(adapter.redirectUri(options));
+              }
+              return url;
+          };
+
+          kc.accountManagement = function() {
+              return adapter.accountManagement();
+          };
+
+          kc.hasRealmRole = function (role) {
+              var access = kc.realmAccess;
+              return !!access && access.roles.indexOf(role) >= 0;
+          };
+
+          kc.hasResourceRole = function(role, resource) {
+              if (!kc.resourceAccess) {
+                  return false;
+              }
+
+              var access = kc.resourceAccess[resource || kc.clientId];
+              return !!access && access.roles.indexOf(role) >= 0;
+          };
+
+          kc.loadUserProfile = function() {
+              var url = getRealmUrl() + '/account';
+              var req = new XMLHttpRequest();
+              req.open('GET', url, true);
+              req.setRequestHeader('Accept', 'application/json');
+              req.setRequestHeader('Authorization', 'bearer ' + kc.token);
+
+              var promise = createPromise(false);
+
+              req.onreadystatechange = function () {
+                  if (req.readyState == 4) {
+                      if (req.status == 200) {
+                          kc.profile = JSON.parse(req.responseText);
+                          promise.setSuccess(kc.profile);
+                      } else {
+                          promise.setError();
+                      }
+                  }
+              };
+
+              req.send();
+
+              return promise.promise;
+          };
+
+          kc.loadUserInfo = function() {
+              var url = kc.endpoints.userinfo();
+              var req = new XMLHttpRequest();
+              req.open('GET', url, true);
+              req.setRequestHeader('Accept', 'application/json');
+              req.setRequestHeader('Authorization', 'bearer ' + kc.token);
+
+              var promise = createPromise(false);
+
+              req.onreadystatechange = function () {
+                  if (req.readyState == 4) {
+                      if (req.status == 200) {
+                          kc.userInfo = JSON.parse(req.responseText);
+                          promise.setSuccess(kc.userInfo);
+                      } else {
+                          promise.setError();
+                      }
+                  }
+              };
+
+              req.send();
+
+              return promise.promise;
+          };
+
+          kc.isTokenExpired = function(minValidity) {
+              if (!kc.tokenParsed || (!kc.refreshToken && kc.flow != 'implicit' )) {
+                  throw 'Not authenticated';
+              }
+
+              if (kc.timeSkew == null) {
+                  console.info('[KEYCLOAK] Unable to determine if token is expired as timeskew is not set');
+                  return true;
+              }
+
+              var expiresIn = kc.tokenParsed['exp'] - Math.ceil(new Date().getTime() / 1000) + kc.timeSkew;
+              if (minValidity) {
+                  expiresIn -= minValidity;
+              }
+              return expiresIn < 0;
+          };
+
+          kc.updateToken = function(minValidity) {
+              var promise = createPromise(false);
+
+              if (!kc.refreshToken) {
+                  promise.setError();
+                  return promise.promise;
+              }
+
+              minValidity = minValidity || 5;
+
+              var exec = function() {
+                  var refreshToken = false;
+                  if (minValidity == -1) {
+                      refreshToken = true;
+                      console.info('[KEYCLOAK] Refreshing token: forced refresh');
+                  } else if (!kc.tokenParsed || kc.isTokenExpired(minValidity)) {
+                      refreshToken = true;
+                      console.info('[KEYCLOAK] Refreshing token: token expired');
+                  }
+
+                  if (!refreshToken) {
+                      promise.setSuccess(false);
+                  } else {
+                      var params = 'grant_type=refresh_token&' + 'refresh_token=' + kc.refreshToken;
+                      var url = kc.endpoints.token();
+
+                      refreshQueue.push(promise);
+
+                      if (refreshQueue.length == 1) {
+                          var req = new XMLHttpRequest();
+                          req.open('POST', url, true);
+                          req.setRequestHeader('Content-type', 'application/x-www-form-urlencoded');
+                          req.withCredentials = true;
+
+                          if (kc.clientId && kc.clientSecret) {
+                              req.setRequestHeader('Authorization', 'Basic ' + btoa(kc.clientId + ':' + kc.clientSecret));
+                          } else {
+                              params += '&client_id=' + encodeURIComponent(kc.clientId);
+                          }
+
+                          var timeLocal = new Date().getTime();
+
+                          req.onreadystatechange = function () {
+                              if (req.readyState == 4) {
+                                  if (req.status == 200) {
+                                      console.info('[KEYCLOAK] Token refreshed');
+
+                                      timeLocal = (timeLocal + new Date().getTime()) / 2;
+
+                                      var tokenResponse = JSON.parse(req.responseText);
+
+                                      setToken(tokenResponse['access_token'], tokenResponse['refresh_token'], tokenResponse['id_token'], timeLocal);
+
+                                      kc.onAuthRefreshSuccess && kc.onAuthRefreshSuccess();
+                                      for (var p = refreshQueue.pop(); p != null; p = refreshQueue.pop()) {
+                                          p.setSuccess(true);
+                                      }
+                                  } else {
+                                      console.warn('[KEYCLOAK] Failed to refresh token');
+
+                                      if (req.status == 400) {
+                                          kc.clearToken();
+                                      }
+
+                                      kc.onAuthRefreshError && kc.onAuthRefreshError();
+                                      for (var p = refreshQueue.pop(); p != null; p = refreshQueue.pop()) {
+                                          p.setError(true);
+                                      }
+                                  }
+                              }
+                          };
+
+                          req.send(params);
+                      }
+                  }
+              };
+
+              if (loginIframe.enable) {
+                  var iframePromise = checkLoginIframe();
+                  iframePromise.success(function() {
+                      exec();
+                  }).error(function() {
+                      promise.setError();
+                  });
+              } else {
+                  exec();
+              }
+
+              return promise.promise;
+          };
+
+          kc.clearToken = function() {
+              if (kc.token) {
+                  setToken(null, null, null);
+                  kc.onAuthLogout && kc.onAuthLogout();
+                  if (kc.loginRequired) {
+                      kc.login();
+                  }
+              }
+          };
+
+          function getRealmUrl() {
+              if (typeof kc.authServerUrl !== 'undefined') {
+                  if (kc.authServerUrl.charAt(kc.authServerUrl.length - 1) == '/') {
+                      return kc.authServerUrl + 'realms/' + encodeURIComponent(kc.realm);
+                  } else {
+                      return kc.authServerUrl + '/realms/' + encodeURIComponent(kc.realm);
+                  }
+              } else {
+              	return undefined$1;
+              }
+          }
+
+          function getOrigin() {
+              if (!window.location.origin) {
+                  return window.location.protocol + "//" + window.location.hostname + (window.location.port ? ':' + window.location.port: '');
+              } else {
+                  return window.location.origin;
+              }
+          }
+
+          function processCallback(oauth, promise) {
+              var code = oauth.code;
+              var error = oauth.error;
+              var prompt = oauth.prompt;
+
+              var timeLocal = new Date().getTime();
+
+              if (error) {
+                  if (prompt != 'none') {
+                      var errorData = { error: error, error_description: oauth.error_description };
+                      kc.onAuthError && kc.onAuthError(errorData);
+                      promise && promise.setError(errorData);
+                  } else {
+                      promise && promise.setSuccess();
+                  }
+                  return;
+              } else if ((kc.flow != 'standard') && (oauth.access_token || oauth.id_token)) {
+                  authSuccess(oauth.access_token, null, oauth.id_token, true);
+              }
+
+              if ((kc.flow != 'implicit') && code) {
+                  var params = 'code=' + code + '&grant_type=authorization_code';
+                  var url = kc.endpoints.token();
+
+                  var req = new XMLHttpRequest();
+                  req.open('POST', url, true);
+                  req.setRequestHeader('Content-type', 'application/x-www-form-urlencoded');
+
+                  if (kc.clientId && kc.clientSecret) {
+                      req.setRequestHeader('Authorization', 'Basic ' + btoa(kc.clientId + ':' + kc.clientSecret));
+                  } else {
+                      params += '&client_id=' + encodeURIComponent(kc.clientId);
+                  }
+
+                  params += '&redirect_uri=' + oauth.redirectUri;
+
+                  req.withCredentials = true;
+
+                  req.onreadystatechange = function() {
+                      if (req.readyState == 4) {
+                          if (req.status == 200) {
+
+                              var tokenResponse = JSON.parse(req.responseText);
+                              authSuccess(tokenResponse['access_token'], tokenResponse['refresh_token'], tokenResponse['id_token'], kc.flow === 'standard');
+                              scheduleCheckIframe();
+                          } else {
+                              kc.onAuthError && kc.onAuthError();
+                              promise && promise.setError();
+                          }
+                      }
+                  };
+
+                  req.send(params);
+              }
+
+              function authSuccess(accessToken, refreshToken, idToken, fulfillPromise) {
+                  timeLocal = (timeLocal + new Date().getTime()) / 2;
+
+                  setToken(accessToken, refreshToken, idToken, timeLocal);
+
+                  if (useNonce && ((kc.tokenParsed && kc.tokenParsed.nonce != oauth.storedNonce) ||
+                      (kc.refreshTokenParsed && kc.refreshTokenParsed.nonce != oauth.storedNonce) ||
+                      (kc.idTokenParsed && kc.idTokenParsed.nonce != oauth.storedNonce))) {
+
+                      console.info('[KEYCLOAK] Invalid nonce, clearing token');
+                      kc.clearToken();
+                      promise && promise.setError();
+                  } else {
+                      if (fulfillPromise) {
+                          kc.onAuthSuccess && kc.onAuthSuccess();
+                          promise && promise.setSuccess();
+                      }
+                  }
+              }
+
+          }
+
+          function loadConfig(url) {
+              var promise = createPromise(true);
+              var configUrl;
+
+              if (!config) {
+                  configUrl = 'keycloak.json';
+              } else if (typeof config === 'string') {
+                  configUrl = config;
+              }
+
+              function setupOidcEndoints(oidcConfiguration) {
+                  if (! oidcConfiguration) {
+                      kc.endpoints = {
+                          authorize: function() {
+                              return getRealmUrl() + '/protocol/openid-connect/auth';
+                          },
+                          token: function() {
+                              return getRealmUrl() + '/protocol/openid-connect/token';
+                          },
+                          logout: function() {
+                              return getRealmUrl() + '/protocol/openid-connect/logout';
+                          },
+                          checkSessionIframe: function() {
+                              var src = getRealmUrl() + '/protocol/openid-connect/login-status-iframe.html';
+                              if (kc.iframeVersion) {
+                                src = src + '?version=' + kc.iframeVersion;
+                              }
+                              return src;
+                          },
+                          register: function() {
+                              return getRealmUrl() + '/protocol/openid-connect/registrations';
+                          },
+                          userinfo: function() {
+                              return getRealmUrl() + '/protocol/openid-connect/userinfo';
+                          }
+                      };
+                  } else {
+                      kc.endpoints = {
+                          authorize: function() {
+                              return oidcConfiguration.authorization_endpoint;
+                          },
+                          token: function() {
+                              return oidcConfiguration.token_endpoint;
+                          },
+                          logout: function() {
+                              if (!oidcConfiguration.end_session_endpoint) {
+                                  throw "Not supported by the OIDC server";
+                              }
+                              return oidcConfiguration.end_session_endpoint;
+                          },
+                          checkSessionIframe: function() {
+                              if (!oidcConfiguration.check_session_iframe) {
+                                  throw "Not supported by the OIDC server";
+                              }
+                              return oidcConfiguration.check_session_iframe;
+                          },
+                          register: function() {
+                              throw 'Redirection to "Register user" page not supported in standard OIDC mode';
+                          },
+                          userinfo: function() {
+                              if (!oidcConfiguration.userinfo_endpoint) {
+                                  throw "Not supported by the OIDC server";
+                              }
+                              return oidcConfiguration.userinfo_endpoint;
+                          }
+                      };
+                  }
+              }
+
+              if (configUrl) {
+                  var req = new XMLHttpRequest();
+                  req.open('GET', configUrl, true);
+                  req.setRequestHeader('Accept', 'application/json');
+
+                  req.onreadystatechange = function () {
+                      if (req.readyState == 4) {
+                          if (req.status == 200 || fileLoaded(req)) {
+                              var config = JSON.parse(req.responseText);
+
+                              kc.authServerUrl = config['auth-server-url'];
+                              kc.realm = config['realm'];
+                              kc.clientId = config['resource'];
+                              kc.clientSecret = (config['credentials'] || {})['secret'];
+                              setupOidcEndoints(null);
+                              promise.setSuccess();
+                          } else {
+                              promise.setError();
+                          }
+                      }
+                  };
+
+                  req.send();
+              } else {
+                  if (!config.clientId) {
+                      throw 'clientId missing';
+                  }
+
+                  kc.clientId = config.clientId;
+                  kc.clientSecret = (config.credentials || {}).secret;
+
+                  var oidcProvider = config['oidcProvider'];
+                  if (!oidcProvider) {
+                      if (!config['url']) {
+                          var scripts = document.getElementsByTagName('script');
+                          for (var i = 0; i < scripts.length; i++) {
+                              if (scripts[i].src.match(/.*keycloak\.js/)) {
+                                  config.url = scripts[i].src.substr(0, scripts[i].src.indexOf('/js/keycloak.js'));
+                                  break;
+                              }
+                          }
+                      }
+                      if (!config.realm) {
+                          throw 'realm missing';
+                      }
+
+                      kc.authServerUrl = config.url;
+                      kc.realm = config.realm;
+                      setupOidcEndoints(null);
+                      promise.setSuccess();
+                  } else {
+                      if (typeof oidcProvider === 'string') {
+                          var oidcProviderConfigUrl;
+                          if (oidcProvider.charAt(oidcProvider.length - 1) == '/') {
+                              oidcProviderConfigUrl = oidcProvider + '.well-known/openid-configuration';
+                          } else {
+                              oidcProviderConfigUrl = oidcProvider + '/.well-known/openid-configuration';
+                          }
+                          var req = new XMLHttpRequest();
+                          req.open('GET', oidcProviderConfigUrl, true);
+                          req.setRequestHeader('Accept', 'application/json');
+
+                          req.onreadystatechange = function () {
+                              if (req.readyState == 4) {
+                                  if (req.status == 200 || fileLoaded(req)) {
+                                      var oidcProviderConfig = JSON.parse(req.responseText);
+                                      setupOidcEndoints(oidcProviderConfig);
+                                      promise.setSuccess();
+                                  } else {
+                                      promise.setError();
+                                  }
+                              }
+                          };
+
+                          req.send();
+                      } else {
+                          setupOidcEndoints(oidcProvider);
+                          promise.setSuccess();
+                      }
+                  }
+              }
+
+              return promise.promise;
+          }
+
+          function fileLoaded(xhr) {
+              return xhr.status == 0 && xhr.responseText && xhr.responseURL.startsWith('file:');
+          }
+
+          function setToken(token, refreshToken, idToken, timeLocal) {
+              if (kc.tokenTimeoutHandle) {
+                  clearTimeout(kc.tokenTimeoutHandle);
+                  kc.tokenTimeoutHandle = null;
+              }
+
+              if (refreshToken) {
+                  kc.refreshToken = refreshToken;
+                  kc.refreshTokenParsed = decodeToken(refreshToken);
+              } else {
+                  delete kc.refreshToken;
+                  delete kc.refreshTokenParsed;
+              }
+
+              if (idToken) {
+                  kc.idToken = idToken;
+                  kc.idTokenParsed = decodeToken(idToken);
+              } else {
+                  delete kc.idToken;
+                  delete kc.idTokenParsed;
+              }
+
+              if (token) {
+                  kc.token = token;
+                  kc.tokenParsed = decodeToken(token);
+                  kc.sessionId = kc.tokenParsed.session_state;
+                  kc.authenticated = true;
+                  kc.subject = kc.tokenParsed.sub;
+                  kc.realmAccess = kc.tokenParsed.realm_access;
+                  kc.resourceAccess = kc.tokenParsed.resource_access;
+
+                  if (timeLocal) {
+                      kc.timeSkew = Math.floor(timeLocal / 1000) - kc.tokenParsed.iat;
+                  }
+
+                  if (kc.timeSkew != null) {
+                      console.info('[KEYCLOAK] Estimated time difference between browser and server is ' + kc.timeSkew + ' seconds');
+
+                      if (kc.onTokenExpired) {
+                          var expiresIn = (kc.tokenParsed['exp'] - (new Date().getTime() / 1000) + kc.timeSkew) * 1000;
+                          console.info('[KEYCLOAK] Token expires in ' + Math.round(expiresIn / 1000) + ' s');
+                          if (expiresIn <= 0) {
+                              kc.onTokenExpired();
+                          } else {
+                              kc.tokenTimeoutHandle = setTimeout(kc.onTokenExpired, expiresIn);
+                          }
+                      }
+                  }
+              } else {
+                  delete kc.token;
+                  delete kc.tokenParsed;
+                  delete kc.subject;
+                  delete kc.realmAccess;
+                  delete kc.resourceAccess;
+
+                  kc.authenticated = false;
+              }
+          }
+
+          function decodeToken(str) {
+              str = str.split('.')[1];
+
+              str = str.replace('/-/g', '+');
+              str = str.replace('/_/g', '/');
+              switch (str.length % 4)
+              {
+                  case 0:
+                      break;
+                  case 2:
+                      str += '==';
+                      break;
+                  case 3:
+                      str += '=';
+                      break;
+                  default:
+                      throw 'Invalid token';
+              }
+
+              str = (str + '===').slice(0, str.length + (str.length % 4));
+              str = str.replace(/-/g, '+').replace(/_/g, '/');
+
+              str = decodeURIComponent(escape(atob(str)));
+
+              str = JSON.parse(str);
+              return str;
+          }
+
+          function createUUID() {
+              var s = [];
+              var hexDigits = '0123456789abcdef';
+              for (var i = 0; i < 36; i++) {
+                  s[i] = hexDigits.substr(Math.floor(Math.random() * 0x10), 1);
+              }
+              s[14] = '4';
+              s[19] = hexDigits.substr((s[19] & 0x3) | 0x8, 1);
+              s[8] = s[13] = s[18] = s[23] = '-';
+              var uuid = s.join('');
+              return uuid;
+          }
+
+          kc.callback_id = 0;
+
+          function parseCallback(url) {
+              var oauth = parseCallbackUrl(url);
+              if (!oauth) {
+                  return;
+              }
+
+              var oauthState = callbackStorage.get(oauth.state);
+
+              if (oauthState) {
+                  oauth.valid = true;
+                  oauth.redirectUri = oauthState.redirectUri;
+                  oauth.storedNonce = oauthState.nonce;
+                  oauth.prompt = oauthState.prompt;
+              }
+
+              return oauth;
+          }
+
+          function parseCallbackUrl(url) {
+              var supportedParams;
+              switch (kc.flow) {
+                  case 'standard':
+                      supportedParams = ['code', 'state', 'session_state'];
+                      break;
+                  case 'implicit':
+                      supportedParams = ['access_token', 'token_type', 'id_token', 'state', 'session_state', 'expires_in'];
+                      break;
+                  case 'hybrid':
+                      supportedParams = ['access_token', 'id_token', 'code', 'state', 'session_state'];
+                      break;
+              }
+
+              supportedParams.push('error');
+              supportedParams.push('error_description');
+              supportedParams.push('error_uri');
+
+              var queryIndex = url.indexOf('?');
+              var fragmentIndex = url.indexOf('#');
+
+              var newUrl;
+              var parsed;
+
+              if (kc.responseMode === 'query' && queryIndex !== -1) {
+                  newUrl = url.substring(0, queryIndex);
+                  parsed = parseCallbackParams(url.substring(queryIndex + 1, fragmentIndex !== -1 ? fragmentIndex : url.length), supportedParams);
+                  if (parsed.paramsString !== '') {
+                      newUrl += '?' + parsed.paramsString;
+                  }
+                  if (fragmentIndex !== -1) {
+                      newUrl += url.substring(fragmentIndex);
+                  }
+              } else if (kc.responseMode === 'fragment' && fragmentIndex !== -1) {
+                  newUrl = url.substring(0, fragmentIndex);
+                  parsed = parseCallbackParams(url.substring(fragmentIndex + 1), supportedParams);
+                  if (parsed.paramsString !== '') {
+                      newUrl += '#' + parsed.paramsString;
+                  }
+              }
+
+              if (parsed && parsed.oauthParams) {
+                  if (kc.flow === 'standard' || kc.flow === 'hybrid') {
+                      if ((parsed.oauthParams.code || parsed.oauthParams.error) && parsed.oauthParams.state) {
+                          parsed.oauthParams.newUrl = newUrl;
+                          return parsed.oauthParams;
+                      }
+                  } else if (kc.flow === 'implicit') {
+                      if ((parsed.oauthParams.access_token || parsed.oauthParams.error) && parsed.oauthParams.state) {
+                          parsed.oauthParams.newUrl = newUrl;
+                          return parsed.oauthParams;
+                      }
+                  }
+              }
+          }
+
+          function parseCallbackParams(paramsString, supportedParams) {
+              var p = paramsString.split('&');
+              var result = {
+                  paramsString: '',
+                  oauthParams: {}
+              };
+              for (var i = 0; i < p.length; i++) {
+                  var t = p[i].split('=');
+                  if (supportedParams.indexOf(t[0]) !== -1) {
+                      result.oauthParams[t[0]] = t[1];
+                  } else {
+                      if (result.paramsString !== '') {
+                          result.paramsString += '&';
+                      }
+                      result.paramsString += p[i];
+                  }
+              }
+              return result;
+          }
+
+          function createPromise(internal) {
+              if (!internal && kc.useNativePromise) {
+                  return createNativePromise();
+              } else {
+                  return createLegacyPromise();
+              }
+          }
+
+          function createNativePromise() {
+              // Need to create a native Promise which also preserves the
+              // interface of the custom promise type previously used by the API
+              var p = {
+                  setSuccess: function(result) {
+                      p.resolve(result);
+                  },
+
+                  setError: function(result) {
+                      p.reject(result);
+                  }
+              };
+              p.promise = new Promise(function(resolve, reject) {
+                  p.resolve = resolve;
+                  p.reject = reject;
+              });
+              return p;
+          }
+
+          function createLegacyPromise() {
+              var p = {
+                  setSuccess: function(result) {
+                      p.success = true;
+                      p.result = result;
+                      if (p.successCallback) {
+                          p.successCallback(result);
+                      }
+                  },
+
+                  setError: function(result) {
+                      p.error = true;
+                      p.result = result;
+                      if (p.errorCallback) {
+                          p.errorCallback(result);
+                      }
+                  },
+
+                  promise: {
+                      success: function(callback) {
+                          if (p.success) {
+                              callback(p.result);
+                          } else if (!p.error) {
+                              p.successCallback = callback;
+                          }
+                          return p.promise;
+                      },
+                      error: function(callback) {
+                          if (p.error) {
+                              callback(p.result);
+                          } else if (!p.success) {
+                              p.errorCallback = callback;
+                          }
+                          return p.promise;
+                      }
+                  }
+              };
+              return p;
+          }
+
+          function setupCheckLoginIframe() {
+              var promise = createPromise(true);
+
+              if (!loginIframe.enable) {
+                  promise.setSuccess();
+                  return promise.promise;
+              }
+
+              if (loginIframe.iframe) {
+                  promise.setSuccess();
+                  return promise.promise;
+              }
+
+              var iframe = document.createElement('iframe');
+              loginIframe.iframe = iframe;
+
+              iframe.onload = function() {
+                  var authUrl = kc.endpoints.authorize();
+                  if (authUrl.charAt(0) === '/') {
+                      loginIframe.iframeOrigin = getOrigin();
+                  } else {
+                      loginIframe.iframeOrigin = authUrl.substring(0, authUrl.indexOf('/', 8));
+                  }
+                  promise.setSuccess();
+              };
+
+              var src = kc.endpoints.checkSessionIframe();
+              iframe.setAttribute('src', src );
+              iframe.setAttribute('title', 'keycloak-session-iframe' );
+              iframe.style.display = 'none';
+              document.body.appendChild(iframe);
+
+              var messageCallback = function(event) {
+                  if ((event.origin !== loginIframe.iframeOrigin) || (loginIframe.iframe.contentWindow !== event.source)) {
+                      return;
+                  }
+
+                  if (!(event.data == 'unchanged' || event.data == 'changed' || event.data == 'error')) {
+                      return;
+                  }
+
+
+                  if (event.data != 'unchanged') {
+                      kc.clearToken();
+                  }
+
+                  var callbacks = loginIframe.callbackList.splice(0, loginIframe.callbackList.length);
+
+                  for (var i = callbacks.length - 1; i >= 0; --i) {
+                      var promise = callbacks[i];
+                      if (event.data == 'error') {
+                          promise.setError();
+                      } else {
+                          promise.setSuccess(event.data == 'unchanged');
+                      }
+                  }
+              };
+
+              window.addEventListener('message', messageCallback, false);
+
+              return promise.promise;
+          }
+
+          function scheduleCheckIframe() {
+              if (loginIframe.enable) {
+                  if (kc.token) {
+                      setTimeout(function() {
+                          checkLoginIframe().success(function(unchanged) {
+                              if (unchanged) {
+                                  scheduleCheckIframe();
+                              }
+                          });
+                      }, loginIframe.interval * 1000);
+                  }
+              }
+          }
+
+          function checkLoginIframe() {
+              var promise = createPromise(true);
+
+              if (loginIframe.iframe && loginIframe.iframeOrigin ) {
+                  var msg = kc.clientId + ' ' + (kc.sessionId ? kc.sessionId : '');
+                  loginIframe.callbackList.push(promise);
+                  var origin = loginIframe.iframeOrigin;
+                  if (loginIframe.callbackList.length == 1) {
+                      loginIframe.iframe.contentWindow.postMessage(msg, origin);
+                  }
+              } else {
+                  promise.setSuccess();
+              }
+
+              return promise.promise;
+          }
+
+          function loadAdapter(type) {
+              if (!type || type == 'default') {
+                  return {
+                      login: function(options) {
+                          window.location.replace(kc.createLoginUrl(options));
+                          return createPromise().promise;
+                      },
+
+                      logout: function(options) {
+                          window.location.replace(kc.createLogoutUrl(options));
+                          return createPromise().promise;
+                      },
+
+                      register: function(options) {
+                          window.location.replace(kc.createRegisterUrl(options));
+                          return createPromise().promise;
+                      },
+
+                      accountManagement : function() {
+                          var accountUrl = kc.createAccountUrl();
+                          if (typeof accountUrl !== 'undefined') {
+                              window.location.href = accountUrl;
+                          } else {
+                              throw "Not supported by the OIDC server";
+                          }
+                          return createPromise(false).promise;
+                      },
+
+                      redirectUri: function(options, encodeHash) {
+                          if (arguments.length == 1) {
+                              encodeHash = true;
+                          }
+
+                          if (options && options.redirectUri) {
+                              return options.redirectUri;
+                          } else if (kc.redirectUri) {
+                              return kc.redirectUri;
+                          } else {
+                              return location.href;
+                          }
+                      }
+                  };
+              }
+
+              if (type == 'cordova') {
+                  loginIframe.enable = false;
+                  var cordovaOpenWindowWrapper = function(loginUrl, target, options) {
+                      if (window.cordova && window.cordova.InAppBrowser) {
+                          // Use inappbrowser for IOS and Android if available
+                          return window.cordova.InAppBrowser.open(loginUrl, target, options);
+                      } else {
+                          return window.open(loginUrl, target, options);
+                      }
+                  };
+
+                  var shallowCloneCordovaOptions = function (userOptions) {
+                      if (userOptions && userOptions.cordovaOptions) {
+                          return Object.keys(userOptions.cordovaOptions).reduce(function (options, optionName) {
+                              options[optionName] = userOptions.cordovaOptions[optionName];
+                              return options;
+                          }, {});
+                      } else {
+                          return {};
+                      }
+                  };
+
+                  var formatCordovaOptions = function (cordovaOptions) {
+                      return Object.keys(cordovaOptions).reduce(function (options, optionName) {
+                          options.push(optionName+"="+cordovaOptions[optionName]);
+                          return options;
+                      }, []).join(",");
+                  };
+
+                  var createCordovaOptions = function (userOptions) {
+                      var cordovaOptions = shallowCloneCordovaOptions(userOptions);
+                      cordovaOptions.location = 'no';
+                      if (userOptions && userOptions.prompt == 'none') {
+                          cordovaOptions.hidden = 'yes';
+                      }                    
+                      return formatCordovaOptions(cordovaOptions);
+                  };
+
+                  return {
+                      login: function(options) {
+                          var promise = createPromise(false);
+
+                          var cordovaOptions = createCordovaOptions(options);
+                          var loginUrl = kc.createLoginUrl(options);
+                          var ref = cordovaOpenWindowWrapper(loginUrl, '_blank', cordovaOptions);
+                          var completed = false;
+                          
+                          var closed = false;
+                          var closeBrowser = function() {
+                              closed = true;
+                              ref.close();
+                          };
+
+                          ref.addEventListener('loadstart', function(event) {
+                              if (event.url.indexOf('http://localhost') == 0) {
+                                  var callback = parseCallback(event.url);
+                                  processCallback(callback, promise);
+                                  closeBrowser();
+                                  completed = true;
+                              }
+                          });
+
+                          ref.addEventListener('loaderror', function(event) {
+                              if (!completed) {
+                                  if (event.url.indexOf('http://localhost') == 0) {
+                                      var callback = parseCallback(event.url);
+                                      processCallback(callback, promise);
+                                      closeBrowser();
+                                      completed = true;
+                                  } else {
+                                      promise.setError();
+                                      closeBrowser();
+                                  }
+                              }
+                          });
+
+                          ref.addEventListener('exit', function(event) {
+                              if (!closed) {
+                                  promise.setError({
+                                      reason: "closed_by_user"
+                                  });
+                              }
+                          });
+
+                          return promise.promise;
+                      },
+
+                      logout: function(options) {
+                          var promise = createPromise(false);
+                          
+                          var logoutUrl = kc.createLogoutUrl(options);
+                          var ref = cordovaOpenWindowWrapper(logoutUrl, '_blank', 'location=no,hidden=yes');
+
+                          var error;
+
+                          ref.addEventListener('loadstart', function(event) {
+                              if (event.url.indexOf('http://localhost') == 0) {
+                                  ref.close();
+                              }
+                          });
+
+                          ref.addEventListener('loaderror', function(event) {
+                              if (event.url.indexOf('http://localhost') == 0) {
+                                  ref.close();
+                              } else {
+                                  error = true;
+                                  ref.close();
+                              }
+                          });
+
+                          ref.addEventListener('exit', function(event) {
+                              if (error) {
+                                  promise.setError();
+                              } else {
+                                  kc.clearToken();
+                                  promise.setSuccess();
+                              }
+                          });
+
+                          return promise.promise;
+                      },
+
+                      register : function() {
+                          var registerUrl = kc.createRegisterUrl();
+                          var cordovaOptions = createCordovaOptions(options);
+                          var ref = cordovaOpenWindowWrapper(registerUrl, '_blank', cordovaOptions);
+                          ref.addEventListener('loadstart', function(event) {
+                              if (event.url.indexOf('http://localhost') == 0) {
+                                  ref.close();
+                              }
+                          });
+                      },
+
+                      accountManagement : function() {
+                          var accountUrl = kc.createAccountUrl();
+                          if (typeof accountUrl !== 'undefined') {
+                              var ref = cordovaOpenWindowWrapper(accountUrl, '_blank', 'location=no');
+                              ref.addEventListener('loadstart', function(event) {
+                                  if (event.url.indexOf('http://localhost') == 0) {
+                                      ref.close();
+                                  }
+                              });
+                          } else {
+                              throw "Not supported by the OIDC server";
+                          }
+                      },
+
+                      redirectUri: function(options) {
+                          return 'http://localhost';
+                      }
+                  }
+              }
+
+              if (type == 'cordova-native') {
+                  loginIframe.enable = false;
+
+                  return {
+                      login: function(options) {
+                          var promise = createPromise(false);
+                          var loginUrl = kc.createLoginUrl(options);
+
+                          universalLinks.subscribe('keycloak', function(event) {
+                              universalLinks.unsubscribe('keycloak');
+                              window.cordova.plugins.browsertab.close();
+                              var oauth = parseCallback(event.url);
+                              processCallback(oauth, promise);
+                          });
+
+                          window.cordova.plugins.browsertab.openUrl(loginUrl);
+                          return promise.promise;
+                      },
+
+                      logout: function(options) {
+                          var promise = createPromise(false);
+                          var logoutUrl = kc.createLogoutUrl(options);
+
+                          universalLinks.subscribe('keycloak', function(event) {
+                              universalLinks.unsubscribe('keycloak');
+                              window.cordova.plugins.browsertab.close();
+                              kc.clearToken();
+                              promise.setSuccess();
+                          });
+
+                          window.cordova.plugins.browsertab.openUrl(logoutUrl);
+                          return promise.promise;
+                      },
+
+                      register : function(options) {
+                          var promise = createPromise(false);
+                          var registerUrl = kc.createRegisterUrl(options);
+                          universalLinks.subscribe('keycloak' , function(event) {
+                              universalLinks.unsubscribe('keycloak');
+                              window.cordova.plugins.browsertab.close();
+                              var oauth = parseCallback(event.url);
+                              processCallback(oauth, promise);
+                          });
+                          window.cordova.plugins.browsertab.openUrl(registerUrl);
+                          return promise.promise;
+
+                      },
+
+                      accountManagement : function() {
+                          var accountUrl = kc.createAccountUrl();
+                          if (typeof accountUrl !== 'undefined') {
+                              window.cordova.plugins.browsertab.openUrl(accountUrl);
+                          } else {
+                              throw "Not supported by the OIDC server";
+                          }
+                      },
+
+                      redirectUri: function(options) {
+                          if (options && options.redirectUri) {
+                              return options.redirectUri;
+                          } else if (kc.redirectUri) {
+                              return kc.redirectUri;
+                          } else {
+                              return "http://localhost";
+                          }
+                      }
+                  }
+              }
+
+              throw 'invalid adapter type: ' + type;
+          }
+
+          var LocalStorage = function() {
+              if (!(this instanceof LocalStorage)) {
+                  return new LocalStorage();
+              }
+
+              localStorage.setItem('kc-test', 'test');
+              localStorage.removeItem('kc-test');
+
+              var cs = this;
+
+              function clearExpired() {
+                  var time = new Date().getTime();
+                  for (var i = 0; i < localStorage.length; i++)  {
+                      var key = localStorage.key(i);
+                      if (key && key.indexOf('kc-callback-') == 0) {
+                          var value = localStorage.getItem(key);
+                          if (value) {
+                              try {
+                                  var expires = JSON.parse(value).expires;
+                                  if (!expires || expires < time) {
+                                      localStorage.removeItem(key);
+                                  }
+                              } catch (err) {
+                                  localStorage.removeItem(key);
+                              }
+                          }
+                      }
+                  }
+              }
+
+              cs.get = function(state) {
+                  if (!state) {
+                      return;
+                  }
+
+                  var key = 'kc-callback-' + state;
+                  var value = localStorage.getItem(key);
+                  if (value) {
+                      localStorage.removeItem(key);
+                      value = JSON.parse(value);
+                  }
+
+                  clearExpired();
+                  return value;
+              };
+
+              cs.add = function(state) {
+                  clearExpired();
+
+                  var key = 'kc-callback-' + state.state;
+                  state.expires = new Date().getTime() + (60 * 60 * 1000);
+                  localStorage.setItem(key, JSON.stringify(state));
+              };
+          };
+
+          var CookieStorage = function() {
+              if (!(this instanceof CookieStorage)) {
+                  return new CookieStorage();
+              }
+
+              var cs = this;
+
+              cs.get = function(state) {
+                  if (!state) {
+                      return;
+                  }
+
+                  var value = getCookie('kc-callback-' + state);
+                  setCookie('kc-callback-' + state, '', cookieExpiration(-100));
+                  if (value) {
+                      return JSON.parse(value);
+                  }
+              };
+
+              cs.add = function(state) {
+                  setCookie('kc-callback-' + state.state, JSON.stringify(state), cookieExpiration(60));
+              };
+
+              cs.removeItem = function(key) {
+                  setCookie(key, '', cookieExpiration(-100));
+              };
+
+              var cookieExpiration = function (minutes) {
+                  var exp = new Date();
+                  exp.setTime(exp.getTime() + (minutes*60*1000));
+                  return exp;
+              };
+
+              var getCookie = function (key) {
+                  var name = key + '=';
+                  var ca = document.cookie.split(';');
+                  for (var i = 0; i < ca.length; i++) {
+                      var c = ca[i];
+                      while (c.charAt(0) == ' ') {
+                          c = c.substring(1);
+                      }
+                      if (c.indexOf(name) == 0) {
+                          return c.substring(name.length, c.length);
+                      }
+                  }
+                  return '';
+              };
+
+              var setCookie = function (key, value, expirationDate) {
+                  var cookie = key + '=' + value + '; '
+                      + 'expires=' + expirationDate.toUTCString() + '; ';
+                  document.cookie = cookie;
+              };
+          };
+
+          function createCallbackStorage() {
+              try {
+                  return new LocalStorage();
+              } catch (err) {
+              }
+
+              return new CookieStorage();
+          }
+      };
+
+      if ( module && 'object' === "object" ) {
+          module.exports = Keycloak;
+      } else {
+          window.Keycloak = Keycloak;
+
+          if ( typeof undefined$1 === "function" && undefined$1.amd ) {
+              undefined$1( "keycloak", [], function () { return Keycloak; } );
+          }
+      }
+  })( window );
+  });
+
+  var installed = false;
+  var index = {
+    install: function install(Vue) {
+      var params = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
+      if (installed) return;
+      installed = true;
+      var defaultParams = {
+        config: window.__BASEURL__ ? "".concat(window.__BASEURL__, "/config") : '/config',
+        init: {
+          onLoad: 'login-required'
+        }
+      };
+      var options = Object.assign({}, defaultParams, params);
+      if (assertOptions(options).hasError) throw new Error("Invalid options given: ".concat(assertOptions(options).error));
+      var watch = new Vue({
+        data: function data() {
+          return {
+            ready: false,
+            authenticated: false,
+            userName: null,
+            fullName: null,
+            token: null,
+            tokenParsed: null,
+            logoutFn: null,
+            loginFn: null,
+            createLoginUrl: null,
+            createLogoutUrl: null
+          };
         }
       });
-    }).catch(function (err) {
-      console.log(err);
+      getConfig(options.config).then(function (config) {
+        init(config, watch, options);
+        Object.defineProperty(Vue.prototype, '$keycloak', {
+          get: function get() {
+            return watch;
+          }
+        });
+      }).catch(function (err) {
+        console.log(err);
+      });
+    }
+  };
+
+  function init(config, watch, options) {
+    var ctor = sanitizeConfig(config);
+    var keycloak$1 = keycloak(ctor);
+    watch.$once('ready', function (cb) {
+      cb && cb();
     });
-  }
-};
+    keycloak$1.init(options.init);
 
-function init(config, watch, options) {
-  var keycloak$$1 = keycloak({
-    'realm': config['authRealm'],
-    'url': config['authUrl'],
-    'clientId': config['authClientId']
-  });
-
-  watch.$once('ready', function (cb) {
-    cb && cb();
-  });
-
-  keycloak$$1.init(options.init);
-  keycloak$$1.onReady = function (authenticated) {
-    updateWatchVariables(authenticated);
-    watch.ready = true;
-    typeof options.onReady === 'function' && watch.$emit('ready', options.onReady.bind(this, keycloak$$1));
-  };
-  keycloak$$1.onAuthSuccess = function () {
-    // Check token validity every 10 seconds (10 000 ms) and, if necessary, update the token.
-    // Refresh token if it's valid for less then 60 seconds
-    var updateTokenInterval = setInterval(function () {
-      return keycloak$$1.updateToken(60).error(function () {
-        keycloak$$1.clearToken();
-      });
-    }, 10000);
-    watch.logoutFn = function () {
-      clearInterval(updateTokenInterval);
-      keycloak$$1.logout({
-        'redirectUri': config['logoutRedirectUri']
-      });
+    keycloak$1.onReady = function (authenticated) {
+      updateWatchVariables(authenticated);
+      watch.ready = true;
+      typeof options.onReady === 'function' && watch.$emit('ready', options.onReady.bind(this, keycloak$1));
     };
-  };
-  keycloak$$1.onAuthRefreshSuccess = function () {
-    updateWatchVariables(true);
-  };
-  keycloak$$1.onAuthRefreshError = function () {
-    console.error('Error while trying to refresh the token');
-  };
-  keycloak$$1.onAuthError = function (errorData) {
-    console.error('Error during authentication: ' + JSON.stringify(errorData));
-  };
 
-  function updateWatchVariables() {
-    var isAuthenticated = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : false;
+    keycloak$1.onAuthSuccess = function () {
+      // Check token validity every 10 seconds (10 000 ms) and, if necessary, update the token.
+      // Refresh token if it's valid for less then 60 seconds
+      var updateTokenInterval = setInterval(function () {
+        return keycloak$1.updateToken(60).error(function () {
+          keycloak$1.clearToken();
+        });
+      }, 10000);
 
-    watch.authenticated = isAuthenticated;
-    watch.loginFn = keycloak$$1.login;
-    watch.createLoginUrl = keycloak$$1.createLoginUrl;
-    watch.createLogoutUrl = keycloak$$1.createLogoutUrl;
-    if (isAuthenticated) {
-      watch.hasRealmRole = keycloak$$1.hasRealmRole;
-      watch.hasResourceRole = keycloak$$1.hasResourceRole;
-      watch.token = keycloak$$1.token;
-      watch.userName = keycloak$$1.tokenParsed['preferred_username'];
-      watch.fullName = keycloak$$1.tokenParsed['name'];
+      watch.logoutFn = function () {
+        clearInterval(updateTokenInterval);
+        keycloak$1.logout(options.logout || {
+          'redirectUri': config['logoutRedirectUri']
+        });
+      };
+    };
+
+    keycloak$1.onAuthRefreshSuccess = function () {
+      updateWatchVariables(true);
+    };
+
+    keycloak$1.onAuthRefreshError = function () {
+      console.error('Error while trying to refresh the token');
+    };
+
+    keycloak$1.onAuthError = function (errorData) {
+      console.error('Error during authentication: ' + JSON.stringify(errorData));
+    };
+
+    function updateWatchVariables() {
+      var isAuthenticated = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : false;
+      watch.authenticated = isAuthenticated;
+      watch.loginFn = keycloak$1.login;
+      watch.createLoginUrl = keycloak$1.createLoginUrl;
+      watch.createLogoutUrl = keycloak$1.createLogoutUrl;
+
+      if (isAuthenticated) {
+        watch.hasRealmRole = keycloak$1.hasRealmRole;
+        watch.hasResourceRole = keycloak$1.hasResourceRole;
+        watch.token = keycloak$1.token;
+        watch.tokenParsed = keycloak$1.tokenParsed;
+        watch.userName = keycloak$1.tokenParsed['preferred_username'];
+        watch.fullName = keycloak$1.tokenParsed['name'];
+      }
     }
   }
-}
 
-function assertOptions(options) {
-  var config = options.config,
-      init = options.init,
-      onReady = options.onReady;
+  function assertOptions(options) {
+    var config = options.config,
+        init = options.init,
+        onReady = options.onReady;
 
-  if (typeof config !== 'string' && !_isObject(config)) {
-    return { hasError: true, error: '\'config\' option must be a string or an object. Found: \'' + config + '\'' };
-  }
-  if (!_isObject(init) || typeof init.onLoad !== 'string') {
-    return { hasError: true, error: '\'init\' option must be an object with an \'onLoad\' property. Found: \'' + init + '\'' };
-  }
-  if (onReady && typeof onReady !== 'function') {
-    return { hasError: true, error: '\'onReady\' option must be a function. Found: \'' + onReady + '\'' };
-  }
-  return {
-    hasError: false,
-    error: null
-  };
-}
+    if (typeof config !== 'string' && !_isObject(config)) {
+      return {
+        hasError: true,
+        error: "'config' option must be a string or an object. Found: '".concat(config, "'")
+      };
+    }
 
-function _isObject(obj) {
-  return obj !== null && (typeof obj === 'undefined' ? 'undefined' : _typeof(obj)) === 'object' && Object.prototype.toString.call(obj) !== '[object Array]';
-}
+    if (!_isObject(init) || typeof init.onLoad !== 'string') {
+      return {
+        hasError: true,
+        error: "'init' option must be an object with an 'onLoad' property. Found: '".concat(init, "'")
+      };
+    }
 
-function getConfig(config) {
-  if (_isObject(config)) return Promise.resolve(config);
-  return new Promise(function (resolve, reject) {
-    var xhr = new XMLHttpRequest();
-    xhr.open('GET', config);
-    xhr.setRequestHeader('Accept', 'application/json');
-    xhr.onreadystatechange = function () {
-      if (xhr.readyState === 4) {
-        if (xhr.status === 200) {
-          resolve(JSON.parse(xhr.responseText));
-        } else {
-          reject(Error(xhr.statusText));
-        }
-      }
+    if (onReady && typeof onReady !== 'function') {
+      return {
+        hasError: true,
+        error: "'onReady' option must be a function. Found: '".concat(onReady, "'")
+      };
+    }
+
+    return {
+      hasError: false,
+      error: null
     };
-    xhr.send();
-  });
-}
+  }
 
-return index;
+  function _isObject(obj) {
+    return obj !== null && _typeof(obj) === 'object' && Object.prototype.toString.call(obj) !== '[object Array]';
+  }
 
-})));
+  function getConfig(config) {
+    if (_isObject(config)) return Promise.resolve(config);
+    return new Promise(function (resolve, reject) {
+      var xhr = new XMLHttpRequest();
+      xhr.open('GET', config);
+      xhr.setRequestHeader('Accept', 'application/json');
+
+      xhr.onreadystatechange = function () {
+        if (xhr.readyState === 4) {
+          if (xhr.status === 200) {
+            resolve(JSON.parse(xhr.responseText));
+          } else {
+            reject(Error(xhr.statusText));
+          }
+        }
+      };
+
+      xhr.send();
+    });
+  }
+
+  function sanitizeConfig(config) {
+    var renameProp = function renameProp(oldProp, newProp, _ref) {
+      var old = _ref[oldProp],
+          others = _objectWithoutProperties(_ref, [oldProp].map(_toPropertyKey));
+
+      return _objectSpread(_defineProperty({}, newProp, old), others);
+    };
+
+    return Object.keys(config).reduce(function (previous, key) {
+      if (['authRealm', 'authUrl', 'authClientId'].includes(key)) {
+        var cleaned = key.replace('auth', '');
+        var newKey = cleaned.charAt(0).toLowerCase() + cleaned.slice(1);
+        return renameProp(key, newKey, previous);
+      }
+
+      return previous;
+    }, config);
+  }
+
+  return index;
+
+}));

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,23 +4,1041 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
-    "acorn": {
-      "version": "5.7.3",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.3.tgz",
-      "integrity": "sha512-T/zvzYRfbVojPWahDsE5evJdHb3oJoQfFbsrKM7w5Zcs++Tr257tia3BmMP8XYVjp1S9RZXQMh7gao96BlqZOw==",
+    "@babel/code-frame": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0.tgz",
+      "integrity": "sha512-OfC2uemaknXr87bdLUkWog7nYuliM9Ij5HUcajsVcMCpQrcLmtxRbVFTIqmcSkSeYRBFBRxs2FiUqFJDLdiebA==",
+      "dev": true,
+      "requires": {
+        "@babel/highlight": "^7.0.0"
+      }
+    },
+    "@babel/core": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.4.3.tgz",
+      "integrity": "sha512-oDpASqKFlbspQfzAE7yaeTmdljSH2ADIvBlb0RwbStltTuWa0+7CCI1fYVINNv9saHPa1W7oaKeuNuKj+RQCvA==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.0.0",
+        "@babel/generator": "^7.4.0",
+        "@babel/helpers": "^7.4.3",
+        "@babel/parser": "^7.4.3",
+        "@babel/template": "^7.4.0",
+        "@babel/traverse": "^7.4.3",
+        "@babel/types": "^7.4.0",
+        "convert-source-map": "^1.1.0",
+        "debug": "^4.1.0",
+        "json5": "^2.1.0",
+        "lodash": "^4.17.11",
+        "resolve": "^1.3.2",
+        "semver": "^5.4.1",
+        "source-map": "^0.5.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "json5": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/json5/-/json5-2.1.0.tgz",
+          "integrity": "sha512-8Mh9h6xViijj36g7Dxi+Y4S6hNGV96vcJZr/SrlHh1LR/pEn/8j/+qIBbs44YKl69Lrfctp4QD+AdWLTMqEZAQ==",
+          "dev": true,
+          "requires": {
+            "minimist": "^1.2.0"
+          }
+        },
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "dev": true
+        },
+        "ms": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+          "dev": true
+        }
+      }
+    },
+    "@babel/generator": {
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.4.0.tgz",
+      "integrity": "sha512-/v5I+a1jhGSKLgZDcmAUZ4K/VePi43eRkUs3yePW1HB1iANOD5tqJXwGSG4BZhSksP8J9ejSlwGeTiiOFZOrXQ==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.4.0",
+        "jsesc": "^2.5.1",
+        "lodash": "^4.17.11",
+        "source-map": "^0.5.0",
+        "trim-right": "^1.0.1"
+      },
+      "dependencies": {
+        "jsesc": {
+          "version": "2.5.2",
+          "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
+          "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
+          "dev": true
+        }
+      }
+    },
+    "@babel/helper-annotate-as-pure": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.0.0.tgz",
+      "integrity": "sha512-3UYcJUj9kvSLbLbUIfQTqzcy5VX7GRZ/CCDrnOaZorFFM01aXp1+GJwuFGV4NDDoAS+mOUyHcO6UD/RfqOks3Q==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "@babel/helper-builder-binary-assignment-operator-visitor": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-builder-binary-assignment-operator-visitor/-/helper-builder-binary-assignment-operator-visitor-7.1.0.tgz",
+      "integrity": "sha512-qNSR4jrmJ8M1VMM9tibvyRAHXQs2PmaksQF7c1CGJNipfe3D8p+wgNwgso/P2A2r2mdgBWAXljNWR0QRZAMW8w==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-explode-assignable-expression": "^7.1.0",
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "@babel/helper-call-delegate": {
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-call-delegate/-/helper-call-delegate-7.4.0.tgz",
+      "integrity": "sha512-SdqDfbVdNQCBp3WhK2mNdDvHd3BD6qbmIc43CAyjnsfCmgHMeqgDcM3BzY2lchi7HBJGJ2CVdynLWbezaE4mmQ==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-hoist-variables": "^7.4.0",
+        "@babel/traverse": "^7.4.0",
+        "@babel/types": "^7.4.0"
+      }
+    },
+    "@babel/helper-define-map": {
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-define-map/-/helper-define-map-7.4.0.tgz",
+      "integrity": "sha512-wAhQ9HdnLIywERVcSvX40CEJwKdAa1ID4neI9NXQPDOHwwA+57DqwLiPEVy2AIyWzAk0CQ8qx4awO0VUURwLtA==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-function-name": "^7.1.0",
+        "@babel/types": "^7.4.0",
+        "lodash": "^4.17.11"
+      }
+    },
+    "@babel/helper-explode-assignable-expression": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-explode-assignable-expression/-/helper-explode-assignable-expression-7.1.0.tgz",
+      "integrity": "sha512-NRQpfHrJ1msCHtKjbzs9YcMmJZOg6mQMmGRB+hbamEdG5PNpaSm95275VD92DvJKuyl0s2sFiDmMZ+EnnvufqA==",
+      "dev": true,
+      "requires": {
+        "@babel/traverse": "^7.1.0",
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "@babel/helper-function-name": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.1.0.tgz",
+      "integrity": "sha512-A95XEoCpb3TO+KZzJ4S/5uW5fNe26DjBGqf1o9ucyLyCmi1dXq/B3c8iaWTfBk3VvetUxl16e8tIrd5teOCfGw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-get-function-arity": "^7.0.0",
+        "@babel/template": "^7.1.0",
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "@babel/helper-get-function-arity": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0.tgz",
+      "integrity": "sha512-r2DbJeg4svYvt3HOS74U4eWKsUAMRH01Z1ds1zx8KNTPtpTL5JAsdFv8BNyOpVqdFhHkkRDIg5B4AsxmkjAlmQ==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "@babel/helper-hoist-variables": {
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.4.0.tgz",
+      "integrity": "sha512-/NErCuoe/et17IlAQFKWM24qtyYYie7sFIrW/tIQXpck6vAu2hhtYYsKLBWQV+BQZMbcIYPU/QMYuTufrY4aQw==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.4.0"
+      }
+    },
+    "@babel/helper-member-expression-to-functions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.0.0.tgz",
+      "integrity": "sha512-avo+lm/QmZlv27Zsi0xEor2fKcqWG56D5ae9dzklpIaY7cQMK5N8VSpaNVPPagiqmy7LrEjK1IWdGMOqPu5csg==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "@babel/helper-module-imports": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.0.0.tgz",
+      "integrity": "sha512-aP/hlLq01DWNEiDg4Jn23i+CXxW/owM4WpDLFUbpjxe4NS3BhLVZQ5i7E0ZrxuQ/vwekIeciyamgB1UIYxxM6A==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "@babel/helper-module-transforms": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.4.3.tgz",
+      "integrity": "sha512-H88T9IySZW25anu5uqyaC1DaQre7ofM+joZtAaO2F8NBdFfupH0SZ4gKjgSFVcvtx/aAirqA9L9Clio2heYbZA==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-module-imports": "^7.0.0",
+        "@babel/helper-simple-access": "^7.1.0",
+        "@babel/helper-split-export-declaration": "^7.0.0",
+        "@babel/template": "^7.2.2",
+        "@babel/types": "^7.2.2",
+        "lodash": "^4.17.11"
+      }
+    },
+    "@babel/helper-optimise-call-expression": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.0.0.tgz",
+      "integrity": "sha512-u8nd9NQePYNQV8iPWu/pLLYBqZBa4ZaY1YWRFMuxrid94wKI1QNt67NEZ7GAe5Kc/0LLScbim05xZFWkAdrj9g==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "@babel/helper-plugin-utils": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0.tgz",
+      "integrity": "sha512-CYAOUCARwExnEixLdB6sDm2dIJ/YgEAKDM1MOeMeZu9Ld/bDgVo8aiWrXwcY7OBh+1Ea2uUcVRcxKk0GJvW7QA==",
       "dev": true
     },
-    "ansi-regex": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+    "@babel/helper-regex": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@babel/helper-regex/-/helper-regex-7.4.3.tgz",
+      "integrity": "sha512-hnoq5u96pLCfgjXuj8ZLX3QQ+6nAulS+zSgi6HulUwFbEruRAKwbGLU5OvXkE14L8XW6XsQEKsIDfgthKLRAyA==",
+      "dev": true,
+      "requires": {
+        "lodash": "^4.17.11"
+      }
+    },
+    "@babel/helper-remap-async-to-generator": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.1.0.tgz",
+      "integrity": "sha512-3fOK0L+Fdlg8S5al8u/hWE6vhufGSn0bN09xm2LXMy//REAF8kDCrYoOBKYmA8m5Nom+sV9LyLCwrFynA8/slg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-annotate-as-pure": "^7.0.0",
+        "@babel/helper-wrap-function": "^7.1.0",
+        "@babel/template": "^7.1.0",
+        "@babel/traverse": "^7.1.0",
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "@babel/helper-replace-supers": {
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.4.0.tgz",
+      "integrity": "sha512-PVwCVnWWAgnal+kJ+ZSAphzyl58XrFeSKSAJRiqg5QToTsjL+Xu1f9+RJ+d+Q0aPhPfBGaYfkox66k86thxNSg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-member-expression-to-functions": "^7.0.0",
+        "@babel/helper-optimise-call-expression": "^7.0.0",
+        "@babel/traverse": "^7.4.0",
+        "@babel/types": "^7.4.0"
+      }
+    },
+    "@babel/helper-simple-access": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.1.0.tgz",
+      "integrity": "sha512-Vk+78hNjRbsiu49zAPALxTb+JUQCz1aolpd8osOF16BGnLtseD21nbHgLPGUwrXEurZgiCOUmvs3ExTu4F5x6w==",
+      "dev": true,
+      "requires": {
+        "@babel/template": "^7.1.0",
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "@babel/helper-split-export-declaration": {
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.4.0.tgz",
+      "integrity": "sha512-7Cuc6JZiYShaZnybDmfwhY4UYHzI6rlqhWjaIqbsJGsIqPimEYy5uh3akSRLMg65LSdSEnJ8a8/bWQN6u2oMGw==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.4.0"
+      }
+    },
+    "@babel/helper-wrap-function": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.2.0.tgz",
+      "integrity": "sha512-o9fP1BZLLSrYlxYEYyl2aS+Flun5gtjTIG8iln+XuEzQTs0PLagAGSXUcqruJwD5fM48jzIEggCKpIfWTcR7pQ==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-function-name": "^7.1.0",
+        "@babel/template": "^7.1.0",
+        "@babel/traverse": "^7.1.0",
+        "@babel/types": "^7.2.0"
+      }
+    },
+    "@babel/helpers": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.4.3.tgz",
+      "integrity": "sha512-BMh7X0oZqb36CfyhvtbSmcWc3GXocfxv3yNsAEuM0l+fAqSO22rQrUpijr3oE/10jCTrB6/0b9kzmG4VetCj8Q==",
+      "dev": true,
+      "requires": {
+        "@babel/template": "^7.4.0",
+        "@babel/traverse": "^7.4.3",
+        "@babel/types": "^7.4.0"
+      }
+    },
+    "@babel/highlight": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0.tgz",
+      "integrity": "sha512-UFMC4ZeFC48Tpvj7C8UgLvtkaUuovQX+5xNWrsIoMG8o2z+XFKjKaN9iVmS84dPwVN00W4wPmqvYoZF3EGAsfw==",
+      "dev": true,
+      "requires": {
+        "chalk": "^2.0.0",
+        "esutils": "^2.0.2",
+        "js-tokens": "^4.0.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        },
+        "js-tokens": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+          "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
+      }
+    },
+    "@babel/parser": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.4.3.tgz",
+      "integrity": "sha512-gxpEUhTS1sGA63EGQGuA+WESPR/6tz6ng7tSHFCmaTJK/cGK8y37cBTspX+U2xCAue2IQVvF6Z0oigmjwD8YGQ==",
       "dev": true
     },
-    "ansi-styles": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-      "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+    "@babel/plugin-proposal-async-generator-functions": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.2.0.tgz",
+      "integrity": "sha512-+Dfo/SCQqrwx48ptLVGLdE39YtWRuKc/Y9I5Fy0P1DDBB9lsAHpjcEJQt+4IifuSOSTLBKJObJqMvaO1pIE8LQ==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@babel/helper-remap-async-to-generator": "^7.1.0",
+        "@babel/plugin-syntax-async-generators": "^7.2.0"
+      }
+    },
+    "@babel/plugin-proposal-json-strings": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-json-strings/-/plugin-proposal-json-strings-7.2.0.tgz",
+      "integrity": "sha512-MAFV1CA/YVmYwZG0fBQyXhmj0BHCB5egZHCKWIFVv/XCxAeVGIHfos3SwDck4LvCllENIAg7xMKOG5kH0dzyUg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@babel/plugin-syntax-json-strings": "^7.2.0"
+      }
+    },
+    "@babel/plugin-proposal-object-rest-spread": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.4.3.tgz",
+      "integrity": "sha512-xC//6DNSSHVjq8O2ge0dyYlhshsH4T7XdCVoxbi5HzLYWfsC5ooFlJjrXk8RcAT+hjHAK9UjBXdylzSoDK3t4g==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@babel/plugin-syntax-object-rest-spread": "^7.2.0"
+      }
+    },
+    "@babel/plugin-proposal-optional-catch-binding": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-catch-binding/-/plugin-proposal-optional-catch-binding-7.2.0.tgz",
+      "integrity": "sha512-mgYj3jCcxug6KUcX4OBoOJz3CMrwRfQELPQ5560F70YQUBZB7uac9fqaWamKR1iWUzGiK2t0ygzjTScZnVz75g==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@babel/plugin-syntax-optional-catch-binding": "^7.2.0"
+      }
+    },
+    "@babel/plugin-proposal-unicode-property-regex": {
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-unicode-property-regex/-/plugin-proposal-unicode-property-regex-7.4.0.tgz",
+      "integrity": "sha512-h/KjEZ3nK9wv1P1FSNb9G079jXrNYR0Ko+7XkOx85+gM24iZbPn0rh4vCftk+5QKY7y1uByFataBTmX7irEF1w==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@babel/helper-regex": "^7.0.0",
+        "regexpu-core": "^4.5.4"
+      },
+      "dependencies": {
+        "jsesc": {
+          "version": "0.5.0",
+          "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
+          "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=",
+          "dev": true
+        },
+        "regexpu-core": {
+          "version": "4.5.4",
+          "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-4.5.4.tgz",
+          "integrity": "sha512-BtizvGtFQKGPUcTy56o3nk1bGRp4SZOTYrDtGNlqCQufptV5IkkLN6Emw+yunAJjzf+C9FQFtvq7IoA3+oMYHQ==",
+          "dev": true,
+          "requires": {
+            "regenerate": "^1.4.0",
+            "regenerate-unicode-properties": "^8.0.2",
+            "regjsgen": "^0.5.0",
+            "regjsparser": "^0.6.0",
+            "unicode-match-property-ecmascript": "^1.0.4",
+            "unicode-match-property-value-ecmascript": "^1.1.0"
+          }
+        },
+        "regjsgen": {
+          "version": "0.5.0",
+          "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.5.0.tgz",
+          "integrity": "sha512-RnIrLhrXCX5ow/E5/Mh2O4e/oa1/jW0eaBKTSy3LaCj+M3Bqvm97GWDp2yUtzIs4LEn65zR2yiYGFqb2ApnzDA==",
+          "dev": true
+        },
+        "regjsparser": {
+          "version": "0.6.0",
+          "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.6.0.tgz",
+          "integrity": "sha512-RQ7YyokLiQBomUJuUG8iGVvkgOLxwyZM8k6d3q5SAXpg4r5TZJZigKFvC6PpD+qQ98bCDC5YelPeA3EucDoNeQ==",
+          "dev": true,
+          "requires": {
+            "jsesc": "~0.5.0"
+          }
+        }
+      }
+    },
+    "@babel/plugin-syntax-async-generators": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.2.0.tgz",
+      "integrity": "sha512-1ZrIRBv2t0GSlcwVoQ6VgSLpLgiN/FVQUzt9znxo7v2Ov4jJrs8RY8tv0wvDmFN3qIdMKWrmMMW6yZ0G19MfGg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0"
+      }
+    },
+    "@babel/plugin-syntax-json-strings": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-json-strings/-/plugin-syntax-json-strings-7.2.0.tgz",
+      "integrity": "sha512-5UGYnMSLRE1dqqZwug+1LISpA403HzlSfsg6P9VXU6TBjcSHeNlw4DxDx7LgpF+iKZoOG/+uzqoRHTdcUpiZNg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0"
+      }
+    },
+    "@babel/plugin-syntax-object-rest-spread": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.2.0.tgz",
+      "integrity": "sha512-t0JKGgqk2We+9may3t0xDdmneaXmyxq0xieYcKHxIsrJO64n1OiMWNUtc5gQK1PA0NpdCRrtZp4z+IUaKugrSA==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0"
+      }
+    },
+    "@babel/plugin-syntax-optional-catch-binding": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.2.0.tgz",
+      "integrity": "sha512-bDe4xKNhb0LI7IvZHiA13kff0KEfaGX/Hv4lMA9+7TEc63hMNvfKo6ZFpXhKuEp+II/q35Gc4NoMeDZyaUbj9w==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0"
+      }
+    },
+    "@babel/plugin-transform-arrow-functions": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.2.0.tgz",
+      "integrity": "sha512-ER77Cax1+8/8jCB9fo4Ud161OZzWN5qawi4GusDuRLcDbDG+bIGYY20zb2dfAFdTRGzrfq2xZPvF0R64EHnimg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0"
+      }
+    },
+    "@babel/plugin-transform-async-to-generator": {
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.4.0.tgz",
+      "integrity": "sha512-EeaFdCeUULM+GPFEsf7pFcNSxM7hYjoj5fiYbyuiXobW4JhFnjAv9OWzNwHyHcKoPNpAfeRDuW6VyaXEDUBa7g==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-module-imports": "^7.0.0",
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@babel/helper-remap-async-to-generator": "^7.1.0"
+      }
+    },
+    "@babel/plugin-transform-block-scoped-functions": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.2.0.tgz",
+      "integrity": "sha512-ntQPR6q1/NKuphly49+QiQiTN0O63uOwjdD6dhIjSWBI5xlrbUFh720TIpzBhpnrLfv2tNH/BXvLIab1+BAI0w==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0"
+      }
+    },
+    "@babel/plugin-transform-block-scoping": {
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.4.0.tgz",
+      "integrity": "sha512-AWyt3k+fBXQqt2qb9r97tn3iBwFpiv9xdAiG+Gr2HpAZpuayvbL55yWrsV3MyHvXk/4vmSiedhDRl1YI2Iy5nQ==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "lodash": "^4.17.11"
+      }
+    },
+    "@babel/plugin-transform-classes": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.4.3.tgz",
+      "integrity": "sha512-PUaIKyFUDtG6jF5DUJOfkBdwAS/kFFV3XFk7Nn0a6vR7ZT8jYw5cGtIlat77wcnd0C6ViGqo/wyNf4ZHytF/nQ==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-annotate-as-pure": "^7.0.0",
+        "@babel/helper-define-map": "^7.4.0",
+        "@babel/helper-function-name": "^7.1.0",
+        "@babel/helper-optimise-call-expression": "^7.0.0",
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@babel/helper-replace-supers": "^7.4.0",
+        "@babel/helper-split-export-declaration": "^7.4.0",
+        "globals": "^11.1.0"
+      },
+      "dependencies": {
+        "globals": {
+          "version": "11.11.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-11.11.0.tgz",
+          "integrity": "sha512-WHq43gS+6ufNOEqlrDBxVEbb8ntfXrfAUU2ZOpCxrBdGKW3gyv8mCxAfIBD0DroPKGrJ2eSsXsLtY9MPntsyTw==",
+          "dev": true
+        }
+      }
+    },
+    "@babel/plugin-transform-computed-properties": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.2.0.tgz",
+      "integrity": "sha512-kP/drqTxY6Xt3NNpKiMomfgkNn4o7+vKxK2DDKcBG9sHj51vHqMBGy8wbDS/J4lMxnqs153/T3+DmCEAkC5cpA==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0"
+      }
+    },
+    "@babel/plugin-transform-destructuring": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.4.3.tgz",
+      "integrity": "sha512-rVTLLZpydDFDyN4qnXdzwoVpk1oaXHIvPEOkOLyr88o7oHxVc/LyrnDx+amuBWGOwUb7D1s/uLsKBNTx08htZg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0"
+      }
+    },
+    "@babel/plugin-transform-dotall-regex": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.4.3.tgz",
+      "integrity": "sha512-9Arc2I0AGynzXRR/oPdSALv3k0rM38IMFyto7kOCwb5F9sLUt2Ykdo3V9yUPR+Bgr4kb6bVEyLkPEiBhzcTeoA==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@babel/helper-regex": "^7.4.3",
+        "regexpu-core": "^4.5.4"
+      },
+      "dependencies": {
+        "jsesc": {
+          "version": "0.5.0",
+          "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
+          "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=",
+          "dev": true
+        },
+        "regexpu-core": {
+          "version": "4.5.4",
+          "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-4.5.4.tgz",
+          "integrity": "sha512-BtizvGtFQKGPUcTy56o3nk1bGRp4SZOTYrDtGNlqCQufptV5IkkLN6Emw+yunAJjzf+C9FQFtvq7IoA3+oMYHQ==",
+          "dev": true,
+          "requires": {
+            "regenerate": "^1.4.0",
+            "regenerate-unicode-properties": "^8.0.2",
+            "regjsgen": "^0.5.0",
+            "regjsparser": "^0.6.0",
+            "unicode-match-property-ecmascript": "^1.0.4",
+            "unicode-match-property-value-ecmascript": "^1.1.0"
+          }
+        },
+        "regjsgen": {
+          "version": "0.5.0",
+          "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.5.0.tgz",
+          "integrity": "sha512-RnIrLhrXCX5ow/E5/Mh2O4e/oa1/jW0eaBKTSy3LaCj+M3Bqvm97GWDp2yUtzIs4LEn65zR2yiYGFqb2ApnzDA==",
+          "dev": true
+        },
+        "regjsparser": {
+          "version": "0.6.0",
+          "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.6.0.tgz",
+          "integrity": "sha512-RQ7YyokLiQBomUJuUG8iGVvkgOLxwyZM8k6d3q5SAXpg4r5TZJZigKFvC6PpD+qQ98bCDC5YelPeA3EucDoNeQ==",
+          "dev": true,
+          "requires": {
+            "jsesc": "~0.5.0"
+          }
+        }
+      }
+    },
+    "@babel/plugin-transform-duplicate-keys": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.2.0.tgz",
+      "integrity": "sha512-q+yuxW4DsTjNceUiTzK0L+AfQ0zD9rWaTLiUqHA8p0gxx7lu1EylenfzjeIWNkPy6e/0VG/Wjw9uf9LueQwLOw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0"
+      }
+    },
+    "@babel/plugin-transform-exponentiation-operator": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.2.0.tgz",
+      "integrity": "sha512-umh4hR6N7mu4Elq9GG8TOu9M0bakvlsREEC+ialrQN6ABS4oDQ69qJv1VtR3uxlKMCQMCvzk7vr17RHKcjx68A==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-builder-binary-assignment-operator-visitor": "^7.1.0",
+        "@babel/helper-plugin-utils": "^7.0.0"
+      }
+    },
+    "@babel/plugin-transform-for-of": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.4.3.tgz",
+      "integrity": "sha512-UselcZPwVWNSURnqcfpnxtMehrb8wjXYOimlYQPBnup/Zld426YzIhNEvuRsEWVHfESIECGrxoI6L5QqzuLH5Q==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0"
+      }
+    },
+    "@babel/plugin-transform-function-name": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.4.3.tgz",
+      "integrity": "sha512-uT5J/3qI/8vACBR9I1GlAuU/JqBtWdfCrynuOkrWG6nCDieZd5przB1vfP59FRHBZQ9DC2IUfqr/xKqzOD5x0A==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-function-name": "^7.1.0",
+        "@babel/helper-plugin-utils": "^7.0.0"
+      }
+    },
+    "@babel/plugin-transform-literals": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-literals/-/plugin-transform-literals-7.2.0.tgz",
+      "integrity": "sha512-2ThDhm4lI4oV7fVQ6pNNK+sx+c/GM5/SaML0w/r4ZB7sAneD/piDJtwdKlNckXeyGK7wlwg2E2w33C/Hh+VFCg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0"
+      }
+    },
+    "@babel/plugin-transform-member-expression-literals": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-member-expression-literals/-/plugin-transform-member-expression-literals-7.2.0.tgz",
+      "integrity": "sha512-HiU3zKkSU6scTidmnFJ0bMX8hz5ixC93b4MHMiYebmk2lUVNGOboPsqQvx5LzooihijUoLR/v7Nc1rbBtnc7FA==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0"
+      }
+    },
+    "@babel/plugin-transform-modules-amd": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.2.0.tgz",
+      "integrity": "sha512-mK2A8ucqz1qhrdqjS9VMIDfIvvT2thrEsIQzbaTdc5QFzhDjQv2CkJJ5f6BXIkgbmaoax3zBr2RyvV/8zeoUZw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-module-transforms": "^7.1.0",
+        "@babel/helper-plugin-utils": "^7.0.0"
+      }
+    },
+    "@babel/plugin-transform-modules-commonjs": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.4.3.tgz",
+      "integrity": "sha512-sMP4JqOTbMJMimqsSZwYWsMjppD+KRyDIUVW91pd7td0dZKAvPmhCaxhOzkzLParKwgQc7bdL9UNv+rpJB0HfA==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-module-transforms": "^7.4.3",
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@babel/helper-simple-access": "^7.1.0"
+      }
+    },
+    "@babel/plugin-transform-modules-systemjs": {
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.4.0.tgz",
+      "integrity": "sha512-gjPdHmqiNhVoBqus5qK60mWPp1CmYWp/tkh11mvb0rrys01HycEGD7NvvSoKXlWEfSM9TcL36CpsK8ElsADptQ==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-hoist-variables": "^7.4.0",
+        "@babel/helper-plugin-utils": "^7.0.0"
+      }
+    },
+    "@babel/plugin-transform-modules-umd": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.2.0.tgz",
+      "integrity": "sha512-BV3bw6MyUH1iIsGhXlOK6sXhmSarZjtJ/vMiD9dNmpY8QXFFQTj+6v92pcfy1iqa8DeAfJFwoxcrS/TUZda6sw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-module-transforms": "^7.1.0",
+        "@babel/helper-plugin-utils": "^7.0.0"
+      }
+    },
+    "@babel/plugin-transform-named-capturing-groups-regex": {
+      "version": "7.4.2",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.4.2.tgz",
+      "integrity": "sha512-NsAuliSwkL3WO2dzWTOL1oZJHm0TM8ZY8ZSxk2ANyKkt5SQlToGA4pzctmq1BEjoacurdwZ3xp2dCQWJkME0gQ==",
+      "dev": true,
+      "requires": {
+        "regexp-tree": "^0.1.0"
+      }
+    },
+    "@babel/plugin-transform-new-target": {
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.4.0.tgz",
+      "integrity": "sha512-6ZKNgMQmQmrEX/ncuCwnnw1yVGoaOW5KpxNhoWI7pCQdA0uZ0HqHGqenCUIENAnxRjy2WwNQ30gfGdIgqJXXqw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0"
+      }
+    },
+    "@babel/plugin-transform-object-super": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.2.0.tgz",
+      "integrity": "sha512-VMyhPYZISFZAqAPVkiYb7dUe2AsVi2/wCT5+wZdsNO31FojQJa9ns40hzZ6U9f50Jlq4w6qwzdBB2uwqZ00ebg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@babel/helper-replace-supers": "^7.1.0"
+      }
+    },
+    "@babel/plugin-transform-parameters": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.4.3.tgz",
+      "integrity": "sha512-ULJYC2Vnw96/zdotCZkMGr2QVfKpIT/4/K+xWWY0MbOJyMZuk660BGkr3bEKWQrrciwz6xpmft39nA4BF7hJuA==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-call-delegate": "^7.4.0",
+        "@babel/helper-get-function-arity": "^7.0.0",
+        "@babel/helper-plugin-utils": "^7.0.0"
+      }
+    },
+    "@babel/plugin-transform-property-literals": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-property-literals/-/plugin-transform-property-literals-7.2.0.tgz",
+      "integrity": "sha512-9q7Dbk4RhgcLp8ebduOpCbtjh7C0itoLYHXd9ueASKAG/is5PQtMR5VJGka9NKqGhYEGn5ITahd4h9QeBMylWQ==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0"
+      }
+    },
+    "@babel/plugin-transform-regenerator": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.4.3.tgz",
+      "integrity": "sha512-kEzotPuOpv6/iSlHroCDydPkKYw7tiJGKlmYp6iJn4a6C/+b2FdttlJsLKYxolYHgotTJ5G5UY5h0qey5ka3+A==",
+      "dev": true,
+      "requires": {
+        "regenerator-transform": "^0.13.4"
+      },
+      "dependencies": {
+        "regenerator-transform": {
+          "version": "0.13.4",
+          "resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.13.4.tgz",
+          "integrity": "sha512-T0QMBjK3J0MtxjPmdIMXm72Wvj2Abb0Bd4HADdfijwMdoIsyQZ6fWC7kDFhk2YinBBEMZDL7Y7wh0J1sGx3S4A==",
+          "dev": true,
+          "requires": {
+            "private": "^0.1.6"
+          }
+        }
+      }
+    },
+    "@babel/plugin-transform-reserved-words": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-reserved-words/-/plugin-transform-reserved-words-7.2.0.tgz",
+      "integrity": "sha512-fz43fqW8E1tAB3DKF19/vxbpib1fuyCwSPE418ge5ZxILnBhWyhtPgz8eh1RCGGJlwvksHkyxMxh0eenFi+kFw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0"
+      }
+    },
+    "@babel/plugin-transform-shorthand-properties": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.2.0.tgz",
+      "integrity": "sha512-QP4eUM83ha9zmYtpbnyjTLAGKQritA5XW/iG9cjtuOI8s1RuL/3V6a3DeSHfKutJQ+ayUfeZJPcnCYEQzaPQqg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0"
+      }
+    },
+    "@babel/plugin-transform-spread": {
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.2.2.tgz",
+      "integrity": "sha512-KWfky/58vubwtS0hLqEnrWJjsMGaOeSBn90Ezn5Jeg9Z8KKHmELbP1yGylMlm5N6TPKeY9A2+UaSYLdxahg01w==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0"
+      }
+    },
+    "@babel/plugin-transform-sticky-regex": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.2.0.tgz",
+      "integrity": "sha512-KKYCoGaRAf+ckH8gEL3JHUaFVyNHKe3ASNsZ+AlktgHevvxGigoIttrEJb8iKN03Q7Eazlv1s6cx2B2cQ3Jabw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@babel/helper-regex": "^7.0.0"
+      }
+    },
+    "@babel/plugin-transform-template-literals": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.2.0.tgz",
+      "integrity": "sha512-FkPix00J9A/XWXv4VoKJBMeSkyY9x/TqIh76wzcdfl57RJJcf8CehQ08uwfhCDNtRQYtHQKBTwKZDEyjE13Lwg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-annotate-as-pure": "^7.0.0",
+        "@babel/helper-plugin-utils": "^7.0.0"
+      }
+    },
+    "@babel/plugin-transform-typeof-symbol": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.2.0.tgz",
+      "integrity": "sha512-2LNhETWYxiYysBtrBTqL8+La0jIoQQnIScUJc74OYvUGRmkskNY4EzLCnjHBzdmb38wqtTaixpo1NctEcvMDZw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0"
+      }
+    },
+    "@babel/plugin-transform-unicode-regex": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.4.3.tgz",
+      "integrity": "sha512-lnSNgkVjL8EMtnE8eSS7t2ku8qvKH3eqNf/IwIfnSPUqzgqYmRwzdsQWv4mNQAN9Nuo6Gz1Y0a4CSmdpu1Pp6g==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@babel/helper-regex": "^7.4.3",
+        "regexpu-core": "^4.5.4"
+      },
+      "dependencies": {
+        "jsesc": {
+          "version": "0.5.0",
+          "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
+          "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=",
+          "dev": true
+        },
+        "regexpu-core": {
+          "version": "4.5.4",
+          "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-4.5.4.tgz",
+          "integrity": "sha512-BtizvGtFQKGPUcTy56o3nk1bGRp4SZOTYrDtGNlqCQufptV5IkkLN6Emw+yunAJjzf+C9FQFtvq7IoA3+oMYHQ==",
+          "dev": true,
+          "requires": {
+            "regenerate": "^1.4.0",
+            "regenerate-unicode-properties": "^8.0.2",
+            "regjsgen": "^0.5.0",
+            "regjsparser": "^0.6.0",
+            "unicode-match-property-ecmascript": "^1.0.4",
+            "unicode-match-property-value-ecmascript": "^1.1.0"
+          }
+        },
+        "regjsgen": {
+          "version": "0.5.0",
+          "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.5.0.tgz",
+          "integrity": "sha512-RnIrLhrXCX5ow/E5/Mh2O4e/oa1/jW0eaBKTSy3LaCj+M3Bqvm97GWDp2yUtzIs4LEn65zR2yiYGFqb2ApnzDA==",
+          "dev": true
+        },
+        "regjsparser": {
+          "version": "0.6.0",
+          "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.6.0.tgz",
+          "integrity": "sha512-RQ7YyokLiQBomUJuUG8iGVvkgOLxwyZM8k6d3q5SAXpg4r5TZJZigKFvC6PpD+qQ98bCDC5YelPeA3EucDoNeQ==",
+          "dev": true,
+          "requires": {
+            "jsesc": "~0.5.0"
+          }
+        }
+      }
+    },
+    "@babel/preset-env": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.4.3.tgz",
+      "integrity": "sha512-FYbZdV12yHdJU5Z70cEg0f6lvtpZ8jFSDakTm7WXeJbLXh4R0ztGEu/SW7G1nJ2ZvKwDhz8YrbA84eYyprmGqw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-module-imports": "^7.0.0",
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@babel/plugin-proposal-async-generator-functions": "^7.2.0",
+        "@babel/plugin-proposal-json-strings": "^7.2.0",
+        "@babel/plugin-proposal-object-rest-spread": "^7.4.3",
+        "@babel/plugin-proposal-optional-catch-binding": "^7.2.0",
+        "@babel/plugin-proposal-unicode-property-regex": "^7.4.0",
+        "@babel/plugin-syntax-async-generators": "^7.2.0",
+        "@babel/plugin-syntax-json-strings": "^7.2.0",
+        "@babel/plugin-syntax-object-rest-spread": "^7.2.0",
+        "@babel/plugin-syntax-optional-catch-binding": "^7.2.0",
+        "@babel/plugin-transform-arrow-functions": "^7.2.0",
+        "@babel/plugin-transform-async-to-generator": "^7.4.0",
+        "@babel/plugin-transform-block-scoped-functions": "^7.2.0",
+        "@babel/plugin-transform-block-scoping": "^7.4.0",
+        "@babel/plugin-transform-classes": "^7.4.3",
+        "@babel/plugin-transform-computed-properties": "^7.2.0",
+        "@babel/plugin-transform-destructuring": "^7.4.3",
+        "@babel/plugin-transform-dotall-regex": "^7.4.3",
+        "@babel/plugin-transform-duplicate-keys": "^7.2.0",
+        "@babel/plugin-transform-exponentiation-operator": "^7.2.0",
+        "@babel/plugin-transform-for-of": "^7.4.3",
+        "@babel/plugin-transform-function-name": "^7.4.3",
+        "@babel/plugin-transform-literals": "^7.2.0",
+        "@babel/plugin-transform-member-expression-literals": "^7.2.0",
+        "@babel/plugin-transform-modules-amd": "^7.2.0",
+        "@babel/plugin-transform-modules-commonjs": "^7.4.3",
+        "@babel/plugin-transform-modules-systemjs": "^7.4.0",
+        "@babel/plugin-transform-modules-umd": "^7.2.0",
+        "@babel/plugin-transform-named-capturing-groups-regex": "^7.4.2",
+        "@babel/plugin-transform-new-target": "^7.4.0",
+        "@babel/plugin-transform-object-super": "^7.2.0",
+        "@babel/plugin-transform-parameters": "^7.4.3",
+        "@babel/plugin-transform-property-literals": "^7.2.0",
+        "@babel/plugin-transform-regenerator": "^7.4.3",
+        "@babel/plugin-transform-reserved-words": "^7.2.0",
+        "@babel/plugin-transform-shorthand-properties": "^7.2.0",
+        "@babel/plugin-transform-spread": "^7.2.0",
+        "@babel/plugin-transform-sticky-regex": "^7.2.0",
+        "@babel/plugin-transform-template-literals": "^7.2.0",
+        "@babel/plugin-transform-typeof-symbol": "^7.2.0",
+        "@babel/plugin-transform-unicode-regex": "^7.4.3",
+        "@babel/types": "^7.4.0",
+        "browserslist": "^4.5.2",
+        "core-js-compat": "^3.0.0",
+        "invariant": "^2.2.2",
+        "js-levenshtein": "^1.1.3",
+        "semver": "^5.5.0"
+      },
+      "dependencies": {
+        "browserslist": {
+          "version": "4.5.4",
+          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.5.4.tgz",
+          "integrity": "sha512-rAjx494LMjqKnMPhFkuLmLp8JWEX0o8ADTGeAbOqaF+XCvYLreZrG5uVjnPBlAQ8REZK4pzXGvp0bWgrFtKaag==",
+          "dev": true,
+          "requires": {
+            "caniuse-lite": "^1.0.30000955",
+            "electron-to-chromium": "^1.3.122",
+            "node-releases": "^1.1.13"
+          }
+        },
+        "caniuse-lite": {
+          "version": "1.0.30000957",
+          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000957.tgz",
+          "integrity": "sha512-8wxNrjAzyiHcLXN/iunskqQnJquQQ6VX8JHfW5kLgAPRSiSuKZiNfmIkP5j7jgyXqAQBSoXyJxfnbCFS0ThSiQ==",
+          "dev": true
+        },
+        "electron-to-chromium": {
+          "version": "1.3.124",
+          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.124.tgz",
+          "integrity": "sha512-glecGr/kFdfeXUHOHAWvGcXrxNU+1wSO/t5B23tT1dtlvYB26GY8aHzZSWD7HqhqC800Lr+w/hQul6C5AF542w==",
+          "dev": true
+        }
+      }
+    },
+    "@babel/template": {
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.4.0.tgz",
+      "integrity": "sha512-SOWwxxClTTh5NdbbYZ0BmaBVzxzTh2tO/TeLTbF6MO6EzVhHTnff8CdBXx3mEtazFBoysmEM6GU/wF+SuSx4Fw==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.0.0",
+        "@babel/parser": "^7.4.0",
+        "@babel/types": "^7.4.0"
+      }
+    },
+    "@babel/traverse": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.4.3.tgz",
+      "integrity": "sha512-HmA01qrtaCwwJWpSKpA948cBvU5BrmviAief/b3AVw936DtcdsTexlbyzNuDnthwhOQ37xshn7hvQaEQk7ISYQ==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.0.0",
+        "@babel/generator": "^7.4.0",
+        "@babel/helper-function-name": "^7.1.0",
+        "@babel/helper-split-export-declaration": "^7.4.0",
+        "@babel/parser": "^7.4.3",
+        "@babel/types": "^7.4.0",
+        "debug": "^4.1.0",
+        "globals": "^11.1.0",
+        "lodash": "^4.17.11"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "globals": {
+          "version": "11.11.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-11.11.0.tgz",
+          "integrity": "sha512-WHq43gS+6ufNOEqlrDBxVEbb8ntfXrfAUU2ZOpCxrBdGKW3gyv8mCxAfIBD0DroPKGrJ2eSsXsLtY9MPntsyTw==",
+          "dev": true
+        },
+        "ms": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+          "dev": true
+        }
+      }
+    },
+    "@babel/types": {
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.4.0.tgz",
+      "integrity": "sha512-aPvkXyU2SPOnztlgo8n9cEiXW755mgyvueUPcpStqdzoSPm0fjO0vQBjLkt3JKJW7ufikfcnMTTPsN1xaTsBPA==",
+      "dev": true,
+      "requires": {
+        "esutils": "^2.0.2",
+        "lodash": "^4.17.11",
+        "to-fast-properties": "^2.0.0"
+      },
+      "dependencies": {
+        "to-fast-properties": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+          "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
+          "dev": true
+        }
+      }
+    },
+    "@types/estree": {
+      "version": "0.0.39",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
+      "integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==",
       "dev": true
+    },
+    "@types/node": {
+      "version": "11.13.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-11.13.0.tgz",
+      "integrity": "sha512-rx29MMkRdVmzunmiA4lzBYJNnXsW/PhG4kMBy2ATsYaDjGGR75dCFEVVROKpNwlVdcUX3xxlghKQOeDPBJobng==",
+      "dev": true
+    },
+    "@types/resolve": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-0.0.8.tgz",
+      "integrity": "sha512-auApPaJf3NPfe18hSoJkp8EbZzer2ISk7o8mCC3M9he/a04+gbMF97NkpD2S8riMGvm4BMRI59/SZQSaLTKpsQ==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
     },
     "arr-diff": {
       "version": "4.0.0",
@@ -56,625 +1074,6 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
       "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
-      "dev": true
-    },
-    "babel-code-frame": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
-      "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
-      "dev": true,
-      "requires": {
-        "chalk": "^1.1.3",
-        "esutils": "^2.0.2",
-        "js-tokens": "^3.0.2"
-      }
-    },
-    "babel-core": {
-      "version": "6.26.3",
-      "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.26.3.tgz",
-      "integrity": "sha512-6jyFLuDmeidKmUEb3NM+/yawG0M2bDZ9Z1qbZP59cyHLz8kYGKYwpJP0UwUKKUiTRNvxfLesJnTedqczP7cTDA==",
-      "dev": true,
-      "requires": {
-        "babel-code-frame": "^6.26.0",
-        "babel-generator": "^6.26.0",
-        "babel-helpers": "^6.24.1",
-        "babel-messages": "^6.23.0",
-        "babel-register": "^6.26.0",
-        "babel-runtime": "^6.26.0",
-        "babel-template": "^6.26.0",
-        "babel-traverse": "^6.26.0",
-        "babel-types": "^6.26.0",
-        "babylon": "^6.18.0",
-        "convert-source-map": "^1.5.1",
-        "debug": "^2.6.9",
-        "json5": "^0.5.1",
-        "lodash": "^4.17.4",
-        "minimatch": "^3.0.4",
-        "path-is-absolute": "^1.0.1",
-        "private": "^0.1.8",
-        "slash": "^1.0.0",
-        "source-map": "^0.5.7"
-      }
-    },
-    "babel-generator": {
-      "version": "6.26.1",
-      "resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.26.1.tgz",
-      "integrity": "sha512-HyfwY6ApZj7BYTcJURpM5tznulaBvyio7/0d4zFOeMPUmfxkCjHocCuoLa2SAGzBI8AREcH3eP3758F672DppA==",
-      "dev": true,
-      "requires": {
-        "babel-messages": "^6.23.0",
-        "babel-runtime": "^6.26.0",
-        "babel-types": "^6.26.0",
-        "detect-indent": "^4.0.0",
-        "jsesc": "^1.3.0",
-        "lodash": "^4.17.4",
-        "source-map": "^0.5.7",
-        "trim-right": "^1.0.1"
-      }
-    },
-    "babel-helper-builder-binary-assignment-operator-visitor": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-helper-builder-binary-assignment-operator-visitor/-/babel-helper-builder-binary-assignment-operator-visitor-6.24.1.tgz",
-      "integrity": "sha1-zORReto1b0IgvK6KAsKzRvmlZmQ=",
-      "dev": true,
-      "requires": {
-        "babel-helper-explode-assignable-expression": "^6.24.1",
-        "babel-runtime": "^6.22.0",
-        "babel-types": "^6.24.1"
-      }
-    },
-    "babel-helper-call-delegate": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-helper-call-delegate/-/babel-helper-call-delegate-6.24.1.tgz",
-      "integrity": "sha1-7Oaqzdx25Bw0YfiL/Fdb0Nqi340=",
-      "dev": true,
-      "requires": {
-        "babel-helper-hoist-variables": "^6.24.1",
-        "babel-runtime": "^6.22.0",
-        "babel-traverse": "^6.24.1",
-        "babel-types": "^6.24.1"
-      }
-    },
-    "babel-helper-define-map": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-helper-define-map/-/babel-helper-define-map-6.26.0.tgz",
-      "integrity": "sha1-pfVtq0GiX5fstJjH66ypgZ+Vvl8=",
-      "dev": true,
-      "requires": {
-        "babel-helper-function-name": "^6.24.1",
-        "babel-runtime": "^6.26.0",
-        "babel-types": "^6.26.0",
-        "lodash": "^4.17.4"
-      }
-    },
-    "babel-helper-explode-assignable-expression": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-helper-explode-assignable-expression/-/babel-helper-explode-assignable-expression-6.24.1.tgz",
-      "integrity": "sha1-8luCz33BBDPFX3BZLVdGQArCLKo=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "^6.22.0",
-        "babel-traverse": "^6.24.1",
-        "babel-types": "^6.24.1"
-      }
-    },
-    "babel-helper-function-name": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.24.1.tgz",
-      "integrity": "sha1-00dbjAPtmCQqJbSDUasYOZ01gKk=",
-      "dev": true,
-      "requires": {
-        "babel-helper-get-function-arity": "^6.24.1",
-        "babel-runtime": "^6.22.0",
-        "babel-template": "^6.24.1",
-        "babel-traverse": "^6.24.1",
-        "babel-types": "^6.24.1"
-      }
-    },
-    "babel-helper-get-function-arity": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.24.1.tgz",
-      "integrity": "sha1-j3eCqpNAfEHTqlCQj4mwMbG2hT0=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "^6.22.0",
-        "babel-types": "^6.24.1"
-      }
-    },
-    "babel-helper-hoist-variables": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-helper-hoist-variables/-/babel-helper-hoist-variables-6.24.1.tgz",
-      "integrity": "sha1-HssnaJydJVE+rbyZFKc/VAi+enY=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "^6.22.0",
-        "babel-types": "^6.24.1"
-      }
-    },
-    "babel-helper-optimise-call-expression": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-6.24.1.tgz",
-      "integrity": "sha1-96E0J7qfc/j0+pk8VKl4gtEkQlc=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "^6.22.0",
-        "babel-types": "^6.24.1"
-      }
-    },
-    "babel-helper-regex": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-helper-regex/-/babel-helper-regex-6.26.0.tgz",
-      "integrity": "sha1-MlxZ+QL4LyS3T6zu0DY5VPZJXnI=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "^6.26.0",
-        "babel-types": "^6.26.0",
-        "lodash": "^4.17.4"
-      }
-    },
-    "babel-helper-remap-async-to-generator": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-helper-remap-async-to-generator/-/babel-helper-remap-async-to-generator-6.24.1.tgz",
-      "integrity": "sha1-XsWBgnrXI/7N04HxySg5BnbkVRs=",
-      "dev": true,
-      "requires": {
-        "babel-helper-function-name": "^6.24.1",
-        "babel-runtime": "^6.22.0",
-        "babel-template": "^6.24.1",
-        "babel-traverse": "^6.24.1",
-        "babel-types": "^6.24.1"
-      }
-    },
-    "babel-helper-replace-supers": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-helper-replace-supers/-/babel-helper-replace-supers-6.24.1.tgz",
-      "integrity": "sha1-v22/5Dk40XNpohPKiov3S2qQqxo=",
-      "dev": true,
-      "requires": {
-        "babel-helper-optimise-call-expression": "^6.24.1",
-        "babel-messages": "^6.23.0",
-        "babel-runtime": "^6.22.0",
-        "babel-template": "^6.24.1",
-        "babel-traverse": "^6.24.1",
-        "babel-types": "^6.24.1"
-      }
-    },
-    "babel-helpers": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-helpers/-/babel-helpers-6.24.1.tgz",
-      "integrity": "sha1-NHHenK7DiOXIUOWX5Yom3fN2ArI=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "^6.22.0",
-        "babel-template": "^6.24.1"
-      }
-    },
-    "babel-messages": {
-      "version": "6.23.0",
-      "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
-      "integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "^6.22.0"
-      }
-    },
-    "babel-plugin-check-es2015-constants": {
-      "version": "6.22.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.22.0.tgz",
-      "integrity": "sha1-NRV7EBQm/S/9PaP3XH0ekYNbv4o=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "^6.22.0"
-      }
-    },
-    "babel-plugin-syntax-async-functions": {
-      "version": "6.13.0",
-      "resolved": "http://registry.npmjs.org/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.13.0.tgz",
-      "integrity": "sha1-ytnK0RkbWtY0vzCuCHI5HgZHvpU=",
-      "dev": true
-    },
-    "babel-plugin-syntax-exponentiation-operator": {
-      "version": "6.13.0",
-      "resolved": "http://registry.npmjs.org/babel-plugin-syntax-exponentiation-operator/-/babel-plugin-syntax-exponentiation-operator-6.13.0.tgz",
-      "integrity": "sha1-nufoM3KQ2pUoggGmpX9BcDF4MN4=",
-      "dev": true
-    },
-    "babel-plugin-syntax-trailing-function-commas": {
-      "version": "6.22.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-trailing-function-commas/-/babel-plugin-syntax-trailing-function-commas-6.22.0.tgz",
-      "integrity": "sha1-ugNgk3+NBuQBgKQ/4NVhb/9TLPM=",
-      "dev": true
-    },
-    "babel-plugin-transform-async-to-generator": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-async-to-generator/-/babel-plugin-transform-async-to-generator-6.24.1.tgz",
-      "integrity": "sha1-ZTbjeK/2yx1VF6wOQOs+n8jQh2E=",
-      "dev": true,
-      "requires": {
-        "babel-helper-remap-async-to-generator": "^6.24.1",
-        "babel-plugin-syntax-async-functions": "^6.8.0",
-        "babel-runtime": "^6.22.0"
-      }
-    },
-    "babel-plugin-transform-es2015-arrow-functions": {
-      "version": "6.22.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-arrow-functions/-/babel-plugin-transform-es2015-arrow-functions-6.22.0.tgz",
-      "integrity": "sha1-RSaSy3EdX3ncf4XkQM5BufJE0iE=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "^6.22.0"
-      }
-    },
-    "babel-plugin-transform-es2015-block-scoped-functions": {
-      "version": "6.22.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoped-functions/-/babel-plugin-transform-es2015-block-scoped-functions-6.22.0.tgz",
-      "integrity": "sha1-u8UbSflk1wy42OC5ToICRs46YUE=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "^6.22.0"
-      }
-    },
-    "babel-plugin-transform-es2015-block-scoping": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.26.0.tgz",
-      "integrity": "sha1-1w9SmcEwjQXBL0Y4E7CgnnOxiV8=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "^6.26.0",
-        "babel-template": "^6.26.0",
-        "babel-traverse": "^6.26.0",
-        "babel-types": "^6.26.0",
-        "lodash": "^4.17.4"
-      }
-    },
-    "babel-plugin-transform-es2015-classes": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-classes/-/babel-plugin-transform-es2015-classes-6.24.1.tgz",
-      "integrity": "sha1-WkxYpQyclGHlZLSyo7+ryXolhNs=",
-      "dev": true,
-      "requires": {
-        "babel-helper-define-map": "^6.24.1",
-        "babel-helper-function-name": "^6.24.1",
-        "babel-helper-optimise-call-expression": "^6.24.1",
-        "babel-helper-replace-supers": "^6.24.1",
-        "babel-messages": "^6.23.0",
-        "babel-runtime": "^6.22.0",
-        "babel-template": "^6.24.1",
-        "babel-traverse": "^6.24.1",
-        "babel-types": "^6.24.1"
-      }
-    },
-    "babel-plugin-transform-es2015-computed-properties": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-computed-properties/-/babel-plugin-transform-es2015-computed-properties-6.24.1.tgz",
-      "integrity": "sha1-b+Ko0WiV1WNPTNmZttNICjCBWbM=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "^6.22.0",
-        "babel-template": "^6.24.1"
-      }
-    },
-    "babel-plugin-transform-es2015-destructuring": {
-      "version": "6.23.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-6.23.0.tgz",
-      "integrity": "sha1-mXux8auWf2gtKwh2/jWNYOdlxW0=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "^6.22.0"
-      }
-    },
-    "babel-plugin-transform-es2015-duplicate-keys": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-duplicate-keys/-/babel-plugin-transform-es2015-duplicate-keys-6.24.1.tgz",
-      "integrity": "sha1-c+s9MQypaePvnskcU3QabxV2Qj4=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "^6.22.0",
-        "babel-types": "^6.24.1"
-      }
-    },
-    "babel-plugin-transform-es2015-for-of": {
-      "version": "6.23.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-for-of/-/babel-plugin-transform-es2015-for-of-6.23.0.tgz",
-      "integrity": "sha1-9HyVsrYT3x0+zC/bdXNiPHUkhpE=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "^6.22.0"
-      }
-    },
-    "babel-plugin-transform-es2015-function-name": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-function-name/-/babel-plugin-transform-es2015-function-name-6.24.1.tgz",
-      "integrity": "sha1-g0yJhTvDaxrw86TF26qU/Y6sqos=",
-      "dev": true,
-      "requires": {
-        "babel-helper-function-name": "^6.24.1",
-        "babel-runtime": "^6.22.0",
-        "babel-types": "^6.24.1"
-      }
-    },
-    "babel-plugin-transform-es2015-literals": {
-      "version": "6.22.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-literals/-/babel-plugin-transform-es2015-literals-6.22.0.tgz",
-      "integrity": "sha1-T1SgLWzWbPkVKAAZox0xklN3yi4=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "^6.22.0"
-      }
-    },
-    "babel-plugin-transform-es2015-modules-amd": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-amd/-/babel-plugin-transform-es2015-modules-amd-6.24.1.tgz",
-      "integrity": "sha1-Oz5UAXI5hC1tGcMBHEvS8AoA0VQ=",
-      "dev": true,
-      "requires": {
-        "babel-plugin-transform-es2015-modules-commonjs": "^6.24.1",
-        "babel-runtime": "^6.22.0",
-        "babel-template": "^6.24.1"
-      }
-    },
-    "babel-plugin-transform-es2015-modules-commonjs": {
-      "version": "6.26.2",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.26.2.tgz",
-      "integrity": "sha512-CV9ROOHEdrjcwhIaJNBGMBCodN+1cfkwtM1SbUHmvyy35KGT7fohbpOxkE2uLz1o6odKK2Ck/tz47z+VqQfi9Q==",
-      "dev": true,
-      "requires": {
-        "babel-plugin-transform-strict-mode": "^6.24.1",
-        "babel-runtime": "^6.26.0",
-        "babel-template": "^6.26.0",
-        "babel-types": "^6.26.0"
-      }
-    },
-    "babel-plugin-transform-es2015-modules-systemjs": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-systemjs/-/babel-plugin-transform-es2015-modules-systemjs-6.24.1.tgz",
-      "integrity": "sha1-/4mhQrkRmpBhlfXxBuzzBdlAfSM=",
-      "dev": true,
-      "requires": {
-        "babel-helper-hoist-variables": "^6.24.1",
-        "babel-runtime": "^6.22.0",
-        "babel-template": "^6.24.1"
-      }
-    },
-    "babel-plugin-transform-es2015-modules-umd": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-umd/-/babel-plugin-transform-es2015-modules-umd-6.24.1.tgz",
-      "integrity": "sha1-rJl+YoXNGO1hdq22B9YCNErThGg=",
-      "dev": true,
-      "requires": {
-        "babel-plugin-transform-es2015-modules-amd": "^6.24.1",
-        "babel-runtime": "^6.22.0",
-        "babel-template": "^6.24.1"
-      }
-    },
-    "babel-plugin-transform-es2015-object-super": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-object-super/-/babel-plugin-transform-es2015-object-super-6.24.1.tgz",
-      "integrity": "sha1-JM72muIcuDp/hgPa0CH1cusnj40=",
-      "dev": true,
-      "requires": {
-        "babel-helper-replace-supers": "^6.24.1",
-        "babel-runtime": "^6.22.0"
-      }
-    },
-    "babel-plugin-transform-es2015-parameters": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.24.1.tgz",
-      "integrity": "sha1-V6w1GrScrxSpfNE7CfZv3wpiXys=",
-      "dev": true,
-      "requires": {
-        "babel-helper-call-delegate": "^6.24.1",
-        "babel-helper-get-function-arity": "^6.24.1",
-        "babel-runtime": "^6.22.0",
-        "babel-template": "^6.24.1",
-        "babel-traverse": "^6.24.1",
-        "babel-types": "^6.24.1"
-      }
-    },
-    "babel-plugin-transform-es2015-shorthand-properties": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-shorthand-properties/-/babel-plugin-transform-es2015-shorthand-properties-6.24.1.tgz",
-      "integrity": "sha1-JPh11nIch2YbvZmkYi5R8U3jiqA=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "^6.22.0",
-        "babel-types": "^6.24.1"
-      }
-    },
-    "babel-plugin-transform-es2015-spread": {
-      "version": "6.22.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-spread/-/babel-plugin-transform-es2015-spread-6.22.0.tgz",
-      "integrity": "sha1-1taKmfia7cRTbIGlQujdnxdG+NE=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "^6.22.0"
-      }
-    },
-    "babel-plugin-transform-es2015-sticky-regex": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-sticky-regex/-/babel-plugin-transform-es2015-sticky-regex-6.24.1.tgz",
-      "integrity": "sha1-AMHNsaynERLN8M9hJsLta0V8zbw=",
-      "dev": true,
-      "requires": {
-        "babel-helper-regex": "^6.24.1",
-        "babel-runtime": "^6.22.0",
-        "babel-types": "^6.24.1"
-      }
-    },
-    "babel-plugin-transform-es2015-template-literals": {
-      "version": "6.22.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-template-literals/-/babel-plugin-transform-es2015-template-literals-6.22.0.tgz",
-      "integrity": "sha1-qEs0UPfp+PH2g51taH2oS7EjbY0=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "^6.22.0"
-      }
-    },
-    "babel-plugin-transform-es2015-typeof-symbol": {
-      "version": "6.23.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-typeof-symbol/-/babel-plugin-transform-es2015-typeof-symbol-6.23.0.tgz",
-      "integrity": "sha1-3sCfHN3/lLUqxz1QXITfWdzOs3I=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "^6.22.0"
-      }
-    },
-    "babel-plugin-transform-es2015-unicode-regex": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-unicode-regex/-/babel-plugin-transform-es2015-unicode-regex-6.24.1.tgz",
-      "integrity": "sha1-04sS9C6nMj9yk4fxinxa4frrNek=",
-      "dev": true,
-      "requires": {
-        "babel-helper-regex": "^6.24.1",
-        "babel-runtime": "^6.22.0",
-        "regexpu-core": "^2.0.0"
-      }
-    },
-    "babel-plugin-transform-exponentiation-operator": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-exponentiation-operator/-/babel-plugin-transform-exponentiation-operator-6.24.1.tgz",
-      "integrity": "sha1-KrDJx/MJj6SJB3cruBP+QejeOg4=",
-      "dev": true,
-      "requires": {
-        "babel-helper-builder-binary-assignment-operator-visitor": "^6.24.1",
-        "babel-plugin-syntax-exponentiation-operator": "^6.8.0",
-        "babel-runtime": "^6.22.0"
-      }
-    },
-    "babel-plugin-transform-regenerator": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.26.0.tgz",
-      "integrity": "sha1-4HA2lvveJ/Cj78rPi03KL3s6jy8=",
-      "dev": true,
-      "requires": {
-        "regenerator-transform": "^0.10.0"
-      }
-    },
-    "babel-plugin-transform-strict-mode": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.24.1.tgz",
-      "integrity": "sha1-1fr3qleKZbvlkc9e2uBKDGcCB1g=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "^6.22.0",
-        "babel-types": "^6.24.1"
-      }
-    },
-    "babel-preset-env": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/babel-preset-env/-/babel-preset-env-1.7.0.tgz",
-      "integrity": "sha512-9OR2afuKDneX2/q2EurSftUYM0xGu4O2D9adAhVfADDhrYDaxXV0rBbevVYoY9n6nyX1PmQW/0jtpJvUNr9CHg==",
-      "dev": true,
-      "requires": {
-        "babel-plugin-check-es2015-constants": "^6.22.0",
-        "babel-plugin-syntax-trailing-function-commas": "^6.22.0",
-        "babel-plugin-transform-async-to-generator": "^6.22.0",
-        "babel-plugin-transform-es2015-arrow-functions": "^6.22.0",
-        "babel-plugin-transform-es2015-block-scoped-functions": "^6.22.0",
-        "babel-plugin-transform-es2015-block-scoping": "^6.23.0",
-        "babel-plugin-transform-es2015-classes": "^6.23.0",
-        "babel-plugin-transform-es2015-computed-properties": "^6.22.0",
-        "babel-plugin-transform-es2015-destructuring": "^6.23.0",
-        "babel-plugin-transform-es2015-duplicate-keys": "^6.22.0",
-        "babel-plugin-transform-es2015-for-of": "^6.23.0",
-        "babel-plugin-transform-es2015-function-name": "^6.22.0",
-        "babel-plugin-transform-es2015-literals": "^6.22.0",
-        "babel-plugin-transform-es2015-modules-amd": "^6.22.0",
-        "babel-plugin-transform-es2015-modules-commonjs": "^6.23.0",
-        "babel-plugin-transform-es2015-modules-systemjs": "^6.23.0",
-        "babel-plugin-transform-es2015-modules-umd": "^6.23.0",
-        "babel-plugin-transform-es2015-object-super": "^6.22.0",
-        "babel-plugin-transform-es2015-parameters": "^6.23.0",
-        "babel-plugin-transform-es2015-shorthand-properties": "^6.22.0",
-        "babel-plugin-transform-es2015-spread": "^6.22.0",
-        "babel-plugin-transform-es2015-sticky-regex": "^6.22.0",
-        "babel-plugin-transform-es2015-template-literals": "^6.22.0",
-        "babel-plugin-transform-es2015-typeof-symbol": "^6.23.0",
-        "babel-plugin-transform-es2015-unicode-regex": "^6.22.0",
-        "babel-plugin-transform-exponentiation-operator": "^6.22.0",
-        "babel-plugin-transform-regenerator": "^6.22.0",
-        "browserslist": "^3.2.6",
-        "invariant": "^2.2.2",
-        "semver": "^5.3.0"
-      }
-    },
-    "babel-register": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-register/-/babel-register-6.26.0.tgz",
-      "integrity": "sha1-btAhFz4vy0htestFxgCahW9kcHE=",
-      "dev": true,
-      "requires": {
-        "babel-core": "^6.26.0",
-        "babel-runtime": "^6.26.0",
-        "core-js": "^2.5.0",
-        "home-or-tmp": "^2.0.0",
-        "lodash": "^4.17.4",
-        "mkdirp": "^0.5.1",
-        "source-map-support": "^0.4.15"
-      }
-    },
-    "babel-runtime": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
-      "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
-      "dev": true,
-      "requires": {
-        "core-js": "^2.4.0",
-        "regenerator-runtime": "^0.11.0"
-      }
-    },
-    "babel-template": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.26.0.tgz",
-      "integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "^6.26.0",
-        "babel-traverse": "^6.26.0",
-        "babel-types": "^6.26.0",
-        "babylon": "^6.18.0",
-        "lodash": "^4.17.4"
-      }
-    },
-    "babel-traverse": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz",
-      "integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
-      "dev": true,
-      "requires": {
-        "babel-code-frame": "^6.26.0",
-        "babel-messages": "^6.23.0",
-        "babel-runtime": "^6.26.0",
-        "babel-types": "^6.26.0",
-        "babylon": "^6.18.0",
-        "debug": "^2.6.8",
-        "globals": "^9.18.0",
-        "invariant": "^2.2.2",
-        "lodash": "^4.17.4"
-      }
-    },
-    "babel-types": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
-      "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "^6.26.0",
-        "esutils": "^2.0.2",
-        "lodash": "^4.17.4",
-        "to-fast-properties": "^1.0.3"
-      }
-    },
-    "babylon": {
-      "version": "6.18.0",
-      "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
-      "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==",
-      "dev": true
-    },
-    "balanced-match": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
       "dev": true
     },
     "base": {
@@ -732,16 +1131,6 @@
         }
       }
     },
-    "brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-      "dev": true,
-      "requires": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
-    },
     "braces": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
@@ -771,20 +1160,10 @@
         }
       }
     },
-    "browserslist": {
-      "version": "3.2.8",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-3.2.8.tgz",
-      "integrity": "sha512-WHVocJYavUwVgVViC0ORikPHQquXwVh939TaelZ4WDqpWgTX/FsGhl/+P4qBUAGcRvtOgDgC+xftNWWp2RUTAQ==",
-      "dev": true,
-      "requires": {
-        "caniuse-lite": "^1.0.30000844",
-        "electron-to-chromium": "^1.3.47"
-      }
-    },
     "builtin-modules": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-2.0.0.tgz",
-      "integrity": "sha512-3U5kUA5VPsRUA3nofm/BXX7GVHKfxz0hOBAPxXrIvHzlDRkQVqEn6yi8QJegxl4LzOHLdvb7XF5dVawa/VVYBg==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-3.0.0.tgz",
+      "integrity": "sha512-hMIeU4K2ilbXV6Uv93ZZ0Avg/M91RaKXucQ+4me2Do1txxBDyDZWCBa5bJSLqoNTRpXTLwEzIk1KmloenDDjhg==",
       "dev": true
     },
     "cache-base": {
@@ -802,25 +1181,6 @@
         "to-object-path": "^0.3.0",
         "union-value": "^1.0.0",
         "unset-value": "^1.0.0"
-      }
-    },
-    "caniuse-lite": {
-      "version": "1.0.30000893",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000893.tgz",
-      "integrity": "sha512-kOddHcTEef+NgN/fs0zmX2brHTNATVOWMEIhlZHCuwQRtXobjSw9pAECc44Op4bTBcavRjkLaPrGomknH7+Jvg==",
-      "dev": true
-    },
-    "chalk": {
-      "version": "1.1.3",
-      "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-      "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-      "dev": true,
-      "requires": {
-        "ansi-styles": "^2.2.1",
-        "escape-string-regexp": "^1.0.2",
-        "has-ansi": "^2.0.0",
-        "strip-ansi": "^3.0.0",
-        "supports-color": "^2.0.0"
       }
     },
     "class-utils": {
@@ -856,16 +1216,25 @@
         "object-visit": "^1.0.0"
       }
     },
+    "color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "dev": true,
+      "requires": {
+        "color-name": "1.1.3"
+      }
+    },
+    "color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+      "dev": true
+    },
     "component-emitter": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
       "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY=",
-      "dev": true
-    },
-    "concat-map": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
       "dev": true
     },
     "convert-source-map": {
@@ -883,10 +1252,53 @@
       "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
       "dev": true
     },
-    "core-js": {
-      "version": "2.5.7",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.7.tgz",
-      "integrity": "sha512-RszJCAxg/PP6uzXVXL6BsxSXx/B05oJAQ2vkJRjyjrEcNVycaqOmNb5OTxZPE3xa5gwZduqza6L9JOCenh/Ecw==",
+    "core-js-compat": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.0.0.tgz",
+      "integrity": "sha512-W/Ppz34uUme3LmXWjMgFlYyGnbo1hd9JvA0LNQ4EmieqVjg2GPYbj3H6tcdP2QGPGWdRKUqZVbVKLNIFVs/HiA==",
+      "dev": true,
+      "requires": {
+        "browserslist": "^4.5.1",
+        "core-js": "3.0.0",
+        "core-js-pure": "3.0.0",
+        "semver": "^5.6.0"
+      },
+      "dependencies": {
+        "browserslist": {
+          "version": "4.5.4",
+          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.5.4.tgz",
+          "integrity": "sha512-rAjx494LMjqKnMPhFkuLmLp8JWEX0o8ADTGeAbOqaF+XCvYLreZrG5uVjnPBlAQ8REZK4pzXGvp0bWgrFtKaag==",
+          "dev": true,
+          "requires": {
+            "caniuse-lite": "^1.0.30000955",
+            "electron-to-chromium": "^1.3.122",
+            "node-releases": "^1.1.13"
+          }
+        },
+        "caniuse-lite": {
+          "version": "1.0.30000957",
+          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000957.tgz",
+          "integrity": "sha512-8wxNrjAzyiHcLXN/iunskqQnJquQQ6VX8JHfW5kLgAPRSiSuKZiNfmIkP5j7jgyXqAQBSoXyJxfnbCFS0ThSiQ==",
+          "dev": true
+        },
+        "core-js": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.0.0.tgz",
+          "integrity": "sha512-WBmxlgH2122EzEJ6GH8o9L/FeoUKxxxZ6q6VUxoTlsE4EvbTWKJb447eyVxTEuq0LpXjlq/kCB2qgBvsYRkLvQ==",
+          "dev": true
+        },
+        "electron-to-chromium": {
+          "version": "1.3.124",
+          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.124.tgz",
+          "integrity": "sha512-glecGr/kFdfeXUHOHAWvGcXrxNU+1wSO/t5B23tT1dtlvYB26GY8aHzZSWD7HqhqC800Lr+w/hQul6C5AF542w==",
+          "dev": true
+        }
+      }
+    },
+    "core-js-pure": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.0.0.tgz",
+      "integrity": "sha512-yPiS3fQd842RZDgo/TAKGgS0f3p2nxssF1H65DIZvZv0Od5CygP8puHXn3IQiM/39VAvgCbdaMQpresrbGgt9g==",
       "dev": true
     },
     "debug": {
@@ -945,21 +1357,6 @@
         }
       }
     },
-    "detect-indent": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
-      "integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
-      "dev": true,
-      "requires": {
-        "repeating": "^2.0.0"
-      }
-    },
-    "electron-to-chromium": {
-      "version": "1.3.80",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.80.tgz",
-      "integrity": "sha512-WClidEWEUNx7OfwXehB0qaxCuetjbKjev2SmXWgybWPLKAThBiMTF/2Pd8GSUDtoGOavxVzdkKwfFAPRSWlkLw==",
-      "dev": true
-    },
     "escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
@@ -967,9 +1364,9 @@
       "dev": true
     },
     "estree-walker": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-0.2.1.tgz",
-      "integrity": "sha1-va/oCVOD2EFNXcLs9MkXO225QS4=",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-0.6.0.tgz",
+      "integrity": "sha512-peq1RfVAVzr3PU/jL31RaOjUKLoZJpObQWJJ+LgfcxDUifyLZ1RjPQZTl0pzj2uJ45b7A7XpyppXvxdEqzo4rw==",
       "dev": true
     },
     "esutils": {
@@ -1143,20 +1540,11 @@
       "integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg=",
       "dev": true
     },
-    "globals": {
-      "version": "9.18.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
-      "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==",
+    "has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
       "dev": true
-    },
-    "has-ansi": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-      "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
-      "dev": true,
-      "requires": {
-        "ansi-regex": "^2.0.0"
-      }
     },
     "has-value": {
       "version": "1.0.0",
@@ -1188,16 +1576,6 @@
             "is-buffer": "^1.1.5"
           }
         }
-      }
-    },
-    "home-or-tmp": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-2.0.0.tgz",
-      "integrity": "sha1-42w/LSyufXRqhX440Y1fMqeILbg=",
-      "dev": true,
-      "requires": {
-        "os-homedir": "^1.0.0",
-        "os-tmpdir": "^1.0.1"
       }
     },
     "invariant": {
@@ -1280,15 +1658,6 @@
       "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
       "dev": true
     },
-    "is-finite": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
-      "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
-      "dev": true,
-      "requires": {
-        "number-is-nan": "^1.0.0"
-      }
-    },
     "is-module": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-module/-/is-module-1.0.0.tgz",
@@ -1342,22 +1711,16 @@
       "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
       "dev": true
     },
+    "js-levenshtein": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/js-levenshtein/-/js-levenshtein-1.1.6.tgz",
+      "integrity": "sha512-X2BB11YZtrRqY4EnQcLX5Rh373zbK4alC1FW7D7MBhL2gtcC17cTnr6DmfHZeS0s2rTHjUTMMHfG7gO8SSdw+g==",
+      "dev": true
+    },
     "js-tokens": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
       "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
-      "dev": true
-    },
-    "jsesc": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
-      "integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s=",
-      "dev": true
-    },
-    "json5": {
-      "version": "0.5.1",
-      "resolved": "http://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
-      "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
       "dev": true
     },
     "keycloak-js": {
@@ -1387,12 +1750,12 @@
       }
     },
     "magic-string": {
-      "version": "0.22.5",
-      "resolved": "http://registry.npmjs.org/magic-string/-/magic-string-0.22.5.tgz",
-      "integrity": "sha512-oreip9rJZkzvA8Qzk9HFs8fZGF/u7H/gtrE8EN6RjKJ9kh2HlC+yQ2QezifqTZfGyiuAV0dRv5a+y/8gBb1m9w==",
+      "version": "0.25.2",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.2.tgz",
+      "integrity": "sha512-iLs9mPjh9IuTtRsqqhNGYcZXGei0Nh/A4xirrsqW7c+QhKVFL2vm7U09ru6cHRD22azaP/wMDgI+HCqbETMTtg==",
       "dev": true,
       "requires": {
-        "vlq": "^0.2.2"
+        "sourcemap-codec": "^1.4.4"
       }
     },
     "map-cache": {
@@ -1410,20 +1773,26 @@
         "object-visit": "^1.0.0"
       }
     },
-    "minimatch": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+    "micromatch": {
+      "version": "3.1.10",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
+      "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
       "dev": true,
       "requires": {
-        "brace-expansion": "^1.1.7"
+        "arr-diff": "^4.0.0",
+        "array-unique": "^0.3.2",
+        "braces": "^2.3.1",
+        "define-property": "^2.0.2",
+        "extend-shallow": "^3.0.2",
+        "extglob": "^2.0.4",
+        "fragment-cache": "^0.2.1",
+        "kind-of": "^6.0.2",
+        "nanomatch": "^1.2.9",
+        "object.pick": "^1.3.0",
+        "regex-not": "^1.0.0",
+        "snapdragon": "^0.8.1",
+        "to-regex": "^3.0.2"
       }
-    },
-    "minimist": {
-      "version": "0.0.8",
-      "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-      "dev": true
     },
     "mixin-deep": {
       "version": "1.3.1",
@@ -1444,15 +1813,6 @@
             "is-plain-object": "^2.0.4"
           }
         }
-      }
-    },
-    "mkdirp": {
-      "version": "0.5.1",
-      "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-      "dev": true,
-      "requires": {
-        "minimist": "0.0.8"
       }
     },
     "ms": {
@@ -1480,11 +1840,14 @@
         "to-regex": "^3.0.1"
       }
     },
-    "number-is-nan": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-      "dev": true
+    "node-releases": {
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.13.tgz",
+      "integrity": "sha512-fKZGviSXR6YvVPyc011NHuJDSD8gFQvLPmc2d2V3BS4gr52ycyQ1Xzs7a8B+Ax3Ni/W+5h1h4SqmzeoA8WZRmA==",
+      "dev": true,
+      "requires": {
+        "semver": "^5.3.0"
+      }
     },
     "object-copy": {
       "version": "0.1.0",
@@ -1535,28 +1898,10 @@
         "isobject": "^3.0.1"
       }
     },
-    "os-homedir": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-      "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
-      "dev": true
-    },
-    "os-tmpdir": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
-      "dev": true
-    },
     "pascalcase": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz",
       "integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ=",
-      "dev": true
-    },
-    "path-is-absolute": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
       "dev": true
     },
     "path-parse": {
@@ -1583,21 +1928,13 @@
       "integrity": "sha512-1G6jJVDWrt0rK99kBjvEtziZNCICAuvIPkSiUFIQxVP06RCVpq3dmDo2oi6ABpYaDYaTRr67BEhL8r1wgEZZKg==",
       "dev": true
     },
-    "regenerator-runtime": {
-      "version": "0.11.1",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
-      "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
-      "dev": true
-    },
-    "regenerator-transform": {
-      "version": "0.10.1",
-      "resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.10.1.tgz",
-      "integrity": "sha512-PJepbvDbuK1xgIgnau7Y90cwaAmO/LCLMI2mPvaXq2heGMR3aWW5/BQvYrhJ8jgmQjXewXvBjzfqKcVOmhjZ6Q==",
+    "regenerate-unicode-properties": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/regenerate-unicode-properties/-/regenerate-unicode-properties-8.0.2.tgz",
+      "integrity": "sha512-SbA/iNrBUf6Pv2zU8Ekv1Qbhv92yxL4hiDa2siuxs4KKn4oOoMDHXjAf7+Nz9qinUQ46B1LcWEi/PhJfPWpZWQ==",
       "dev": true,
       "requires": {
-        "babel-runtime": "^6.18.0",
-        "babel-types": "^6.19.0",
-        "private": "^0.1.6"
+        "regenerate": "^1.4.0"
       }
     },
     "regex-not": {
@@ -1610,39 +1947,11 @@
         "safe-regex": "^1.1.0"
       }
     },
-    "regexpu-core": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-2.0.0.tgz",
-      "integrity": "sha1-SdA4g3uNz4v6W5pCE5k45uoq4kA=",
-      "dev": true,
-      "requires": {
-        "regenerate": "^1.2.1",
-        "regjsgen": "^0.2.0",
-        "regjsparser": "^0.1.4"
-      }
-    },
-    "regjsgen": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz",
-      "integrity": "sha1-bAFq3qxVT3WCP+N6wFuS1aTtsfc=",
-      "dev": true
-    },
-    "regjsparser": {
+    "regexp-tree": {
       "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
-      "integrity": "sha1-fuj4Tcb6eS0/0K4ijSS9lJ6tIFw=",
-      "dev": true,
-      "requires": {
-        "jsesc": "~0.5.0"
-      },
-      "dependencies": {
-        "jsesc": {
-          "version": "0.5.0",
-          "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
-          "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=",
-          "dev": true
-        }
-      }
+      "resolved": "https://registry.npmjs.org/regexp-tree/-/regexp-tree-0.1.5.tgz",
+      "integrity": "sha512-nUmxvfJyAODw+0B13hj8CFVAxhe7fDEAgJgaotBu3nnR+IgGgZq59YedJP5VYTlkEfqjuK6TuRpnymKdatLZfQ==",
+      "dev": true
     },
     "repeat-element": {
       "version": "1.1.3",
@@ -1655,15 +1964,6 @@
       "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
       "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
       "dev": true
-    },
-    "repeating": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
-      "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
-      "dev": true,
-      "requires": {
-        "is-finite": "^1.0.0"
-      }
     },
     "resolve": {
       "version": "1.8.1",
@@ -1687,99 +1987,88 @@
       "dev": true
     },
     "rollup": {
-      "version": "0.50.1",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-0.50.1.tgz",
-      "integrity": "sha512-XwrnqjSTk+yR8GbP6hiJuVe83MVmBw/gm4P3qP34A10fRXvv6ppl0ZUg1+Pj1tIZSR/aw5ZaILLEiVxwXIAdAw==",
-      "dev": true
-    },
-    "rollup-plugin-babel": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/rollup-plugin-babel/-/rollup-plugin-babel-3.0.7.tgz",
-      "integrity": "sha512-bVe2y0z/V5Ax1qU8NX/0idmzIwJPdUGu8Xx3vXH73h0yGjxfv2gkFI82MBVg49SlsFlLTBadBHb67zy4TWM3hA==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-1.9.0.tgz",
+      "integrity": "sha512-cNZx9MLpKFMSaObdVFeu8nXw8gfw6yjuxWjt5mRCJcBZrAJ0NHAYwemKjayvYvhLaNNkf3+kS2DKRKS5J6NRVg==",
       "dev": true,
       "requires": {
-        "rollup-pluginutils": "^1.5.0"
+        "@types/estree": "0.0.39",
+        "@types/node": "^11.13.0",
+        "acorn": "^6.1.1"
+      },
+      "dependencies": {
+        "acorn": {
+          "version": "6.1.1",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.1.1.tgz",
+          "integrity": "sha512-jPTiwtOxaHNaAPg/dmrJ/beuzLRnXtB0kQPQ8JpotKJgTB6rX6c8mlf315941pyjBSaPg8NHXS9fhP4u17DpGA==",
+          "dev": true
+        }
+      }
+    },
+    "rollup-plugin-babel": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-babel/-/rollup-plugin-babel-4.3.2.tgz",
+      "integrity": "sha512-KfnizE258L/4enADKX61ozfwGHoqYauvoofghFJBhFnpH9Sb9dNPpWg8QHOaAfVASUYV8w0mCx430i9z0LJoJg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-module-imports": "^7.0.0",
+        "rollup-pluginutils": "^2.3.0"
       }
     },
     "rollup-plugin-commonjs": {
-      "version": "8.4.1",
-      "resolved": "http://registry.npmjs.org/rollup-plugin-commonjs/-/rollup-plugin-commonjs-8.4.1.tgz",
-      "integrity": "sha512-mg+WuD+jlwoo8bJtW3Mvx7Tz6TsIdMsdhuvCnDMoyjh0oxsVgsjB/N0X984RJCWwc5IIiqNVJhXeeITcc73++A==",
+      "version": "9.3.4",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-commonjs/-/rollup-plugin-commonjs-9.3.4.tgz",
+      "integrity": "sha512-DTZOvRoiVIHHLFBCL4pFxOaJt8pagxsVldEXBOn6wl3/V21wVaj17HFfyzTsQUuou3sZL3lEJZVWKPFblJfI6w==",
       "dev": true,
       "requires": {
-        "acorn": "^5.2.1",
-        "estree-walker": "^0.5.0",
-        "magic-string": "^0.22.4",
-        "resolve": "^1.4.0",
-        "rollup-pluginutils": "^2.0.1"
+        "estree-walker": "^0.6.0",
+        "magic-string": "^0.25.2",
+        "resolve": "^1.10.0",
+        "rollup-pluginutils": "^2.6.0"
       },
       "dependencies": {
-        "estree-walker": {
-          "version": "0.5.2",
-          "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-0.5.2.tgz",
-          "integrity": "sha512-XpCnW/AE10ws/kDAs37cngSkvgIR8aN3G0MS85m7dUpuK2EREo9VJ00uvw6Dg/hXEpfsE1I1TvJOJr+Z+TL+ig==",
-          "dev": true
-        },
-        "rollup-pluginutils": {
-          "version": "2.4.1",
-          "resolved": "https://registry.npmjs.org/rollup-pluginutils/-/rollup-pluginutils-2.4.1.tgz",
-          "integrity": "sha512-wesMQ9/172IJDIW/lYWm0vW0LiKe5Ekjws481R7z9WTRtmO59cqyM/2uUlxvf6yzm/fElFmHUobeQOYz46dZJw==",
+        "resolve": {
+          "version": "1.10.0",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.10.0.tgz",
+          "integrity": "sha512-3sUr9aq5OfSg2S9pNtPA9hL1FVEAjvfOC4leW0SNf/mpnaakz2a9femSd6LqAww2RaFctwyf1lCqnTHuF1rxDg==",
           "dev": true,
           "requires": {
-            "estree-walker": "^0.6.0",
-            "micromatch": "^3.1.10"
-          },
-          "dependencies": {
-            "estree-walker": {
-              "version": "0.6.0",
-              "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-0.6.0.tgz",
-              "integrity": "sha512-peq1RfVAVzr3PU/jL31RaOjUKLoZJpObQWJJ+LgfcxDUifyLZ1RjPQZTl0pzj2uJ45b7A7XpyppXvxdEqzo4rw==",
-              "dev": true
-            },
-            "micromatch": {
-              "version": "3.1.10",
-              "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
-              "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
-              "dev": true,
-              "requires": {
-                "arr-diff": "^4.0.0",
-                "array-unique": "^0.3.2",
-                "braces": "^2.3.1",
-                "define-property": "^2.0.2",
-                "extend-shallow": "^3.0.2",
-                "extglob": "^2.0.4",
-                "fragment-cache": "^0.2.1",
-                "kind-of": "^6.0.2",
-                "nanomatch": "^1.2.9",
-                "object.pick": "^1.3.0",
-                "regex-not": "^1.0.0",
-                "snapdragon": "^0.8.1",
-                "to-regex": "^3.0.2"
-              }
-            }
+            "path-parse": "^1.0.6"
           }
         }
       }
     },
     "rollup-plugin-node-resolve": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/rollup-plugin-node-resolve/-/rollup-plugin-node-resolve-3.4.0.tgz",
-      "integrity": "sha512-PJcd85dxfSBWih84ozRtBkB731OjXk0KnzN0oGp7WOWcarAFkVa71cV5hTJg2qpVsV2U8EUwrzHP3tvy9vS3qg==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-node-resolve/-/rollup-plugin-node-resolve-4.1.0.tgz",
+      "integrity": "sha512-N7eBrK0gpdAVQTk5SmsO2h39LlLQMNXalu6Mo6RGWx/hZtq0+gwssT+W2IdF9im2rDNGjUF7HLnxMd9uLiI5+Q==",
       "dev": true,
       "requires": {
-        "builtin-modules": "^2.0.0",
+        "@types/resolve": "0.0.8",
+        "builtin-modules": "^3.0.0",
         "is-module": "^1.0.0",
-        "resolve": "^1.1.6"
+        "resolve": "^1.10.0"
+      },
+      "dependencies": {
+        "resolve": {
+          "version": "1.10.0",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.10.0.tgz",
+          "integrity": "sha512-3sUr9aq5OfSg2S9pNtPA9hL1FVEAjvfOC4leW0SNf/mpnaakz2a9femSd6LqAww2RaFctwyf1lCqnTHuF1rxDg==",
+          "dev": true,
+          "requires": {
+            "path-parse": "^1.0.6"
+          }
+        }
       }
     },
     "rollup-pluginutils": {
-      "version": "1.5.2",
-      "resolved": "http://registry.npmjs.org/rollup-pluginutils/-/rollup-pluginutils-1.5.2.tgz",
-      "integrity": "sha1-HhVud4+UtyVb+hs9AXi+j1xVJAg=",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/rollup-pluginutils/-/rollup-pluginutils-2.6.0.tgz",
+      "integrity": "sha512-aGQwspEF8oPKvg37u3p7h0cYNwmJR1sCBMZGZ5b9qy8HGtETknqjzcxrDRrcAnJNXN18lBH4Q9vZYth/p4n8jQ==",
       "dev": true,
       "requires": {
-        "estree-walker": "^0.2.1",
-        "minimatch": "^3.0.2"
+        "estree-walker": "^0.6.0",
+        "micromatch": "^3.1.10"
       }
     },
     "safe-buffer": {
@@ -1825,12 +2114,6 @@
           }
         }
       }
-    },
-    "slash": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
-      "integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU=",
-      "dev": true
     },
     "snapdragon": {
       "version": "0.8.2",
@@ -1958,19 +2241,16 @@
         "urix": "^0.1.0"
       }
     },
-    "source-map-support": {
-      "version": "0.4.18",
-      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.18.tgz",
-      "integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
-      "dev": true,
-      "requires": {
-        "source-map": "^0.5.6"
-      }
-    },
     "source-map-url": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.0.tgz",
       "integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=",
+      "dev": true
+    },
+    "sourcemap-codec": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.4.tgz",
+      "integrity": "sha512-CYAPYdBu34781kLHkaW3m6b/uUSyMOC2R61gcYMWooeuaGtjof86ZA/8T+qVPPt7np1085CR9hmMGrySwEc8Xg==",
       "dev": true
     },
     "split-string": {
@@ -2002,27 +2282,6 @@
           }
         }
       }
-    },
-    "strip-ansi": {
-      "version": "3.0.1",
-      "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-      "dev": true,
-      "requires": {
-        "ansi-regex": "^2.0.0"
-      }
-    },
-    "supports-color": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-      "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-      "dev": true
-    },
-    "to-fast-properties": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
-      "integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc=",
-      "dev": true
     },
     "to-object-path": {
       "version": "0.3.0",
@@ -2070,6 +2329,34 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
       "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=",
+      "dev": true
+    },
+    "unicode-canonical-property-names-ecmascript": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-1.0.4.tgz",
+      "integrity": "sha512-jDrNnXWHd4oHiTZnx/ZG7gtUTVp+gCcTTKr8L0HjlwphROEW3+Him+IpvC+xcJEFegapiMZyZe02CyuOnRmbnQ==",
+      "dev": true
+    },
+    "unicode-match-property-ecmascript": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/unicode-match-property-ecmascript/-/unicode-match-property-ecmascript-1.0.4.tgz",
+      "integrity": "sha512-L4Qoh15vTfntsn4P1zqnHulG0LdXgjSO035fEpdtp6YxXhMT51Q6vgM5lYdG/5X3MjS+k/Y9Xw4SFCY9IkR0rg==",
+      "dev": true,
+      "requires": {
+        "unicode-canonical-property-names-ecmascript": "^1.0.4",
+        "unicode-property-aliases-ecmascript": "^1.0.4"
+      }
+    },
+    "unicode-match-property-value-ecmascript": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/unicode-match-property-value-ecmascript/-/unicode-match-property-value-ecmascript-1.1.0.tgz",
+      "integrity": "sha512-hDTHvaBk3RmFzvSl0UVrUmC3PuW9wKVnpoUDYH0JDkSIovzw+J5viQmeYHxVSBptubnr7PbH2e0fnpDRQnQl5g==",
+      "dev": true
+    },
+    "unicode-property-aliases-ecmascript": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-1.0.5.tgz",
+      "integrity": "sha512-L5RAqCfXqAwR3RriF8pM0lU0w4Ryf/GgzONwi6KnL1taJQa7x1TCxdJnILX59WIGOwR57IVxn7Nej0fz1Ny6fw==",
       "dev": true
     },
     "union-value": {
@@ -2157,12 +2444,6 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",
       "integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==",
-      "dev": true
-    },
-    "vlq": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/vlq/-/vlq-0.2.3.tgz",
-      "integrity": "sha512-DRibZL6DsNhIgYQ+wNdWDL2SL3bKPlVrRiBqV5yuMm++op8W4kGFtaQfCs4KEJn0wBZcHVHJ3eoywX8983k1ow==",
       "dev": true
     }
   }

--- a/package.json
+++ b/package.json
@@ -23,12 +23,12 @@
     "keycloak"
   ],
   "devDependencies": {
-    "babel-core": "^6.26.0",
-    "babel-preset-env": "^1.6.1",
-    "rollup": "^0.50.0",
-    "rollup-plugin-babel": "^3.0.2",
-    "rollup-plugin-commonjs": "^8.2.4",
-    "rollup-plugin-node-resolve": "^3.0.0"
+    "@babel/core": "^7.4.3",
+    "@babel/preset-env": "^7.4.3",
+    "rollup": "^1.9.0",
+    "rollup-plugin-babel": "^4.3.2",
+    "rollup-plugin-commonjs": "^9.3.4",
+    "rollup-plugin-node-resolve": "^4.1.0"
   },
   "scripts": {
     "build": "rollup -c",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -4,17 +4,21 @@ import babel from 'rollup-plugin-babel'
 import pkg from './package.json'
 
 const version = process.env.VERSION || require('./package.json').version
+const banner =
+`/*!
+  * vue-keycloak-js v${version}
+  * @license ISC
+  */`
+const name = 'dsb-vue-keycloak'
 
 // CommonJS (for Node), ES module (for bundlers) and browser-friendly UMD build.
 export default {
-  banner: `/* vue-keycloak-js v${version} */`,
   input: 'src/index.js',
   output: [
-    {file: pkg.main, format: 'cjs'},
-    {file: pkg.module, format: 'es'},
-    {file: pkg.browser, format: 'umd'}
+    { file: pkg.main, format: 'cjs', banner, name },
+    { file: pkg.module, format: 'es', banner, name },
+    { file: pkg.browser, format: 'umd', banner, name }
   ],
-  name: 'dsb-vue-keycloak',
   plugins: [
     resolve(), // so Rollup can find `keycloak-js`
     commonjs(), // so Rollup can convert `keycloak-js` to an ES module

--- a/src/index.js
+++ b/src/index.js
@@ -22,6 +22,7 @@ export default {
           userName: null,
           fullName: null,
           token: null,
+          tokenParsed: null,
           logoutFn: null,
           loginFn: null,
           createLoginUrl: null,
@@ -45,11 +46,7 @@ export default {
 }
 
 function init (config, watch, options) {
-  const keycloak = Keycloak({
-    'realm': config['authRealm'],
-    'url': config['authUrl'],
-    'clientId': config['authClientId']
-  })
+  const keycloak = Keycloak(config)
 
   watch.$once('ready', function (cb) {
     cb && cb()
@@ -69,9 +66,7 @@ function init (config, watch, options) {
     }), 10000)
     watch.logoutFn = () => {
       clearInterval(updateTokenInterval)
-      keycloak.logout({
-        'redirectUri': config['logoutRedirectUri']
-      })
+      keycloak.logout(options.logout)
     }
   }
   keycloak.onAuthRefreshSuccess = function () {
@@ -93,6 +88,7 @@ function init (config, watch, options) {
       watch.hasRealmRole = keycloak.hasRealmRole
       watch.hasResourceRole = keycloak.hasResourceRole
       watch.token = keycloak.token
+      watch.tokenParsed = keycloak.tokenParsed
       watch.userName = keycloak.tokenParsed['preferred_username']
       watch.fullName = keycloak.tokenParsed['name']
     }


### PR DESCRIPTION
#8, #9, #11: Allow for user-defined object as Keycloak constructor (#8, #11) and expose Keycloak's tokenParsed property (#9). **This is a breaking change**, as the config object now no longer expects hardcoded keys (authUrl, authClientId, authRealm). Also, the logoutFn no longer uses the 'logoutRedirectUri' property from the config object, but rather as a separate option.

If merged, this PR will result in a new major version.