### PR TITLE
Add onInitError callback and fix onReady callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ You can pass in an object as options to the plugin. The following keys are valid
 |`init`|Object|`{onLoad: 'login-required'}`
 |`logout`|Object|
 |`onReady`|Function(keycloak)|
+|`onInitError`|Function(error)|
 
 ### config
 
@@ -222,6 +223,13 @@ Vue.use(VueKeyCloak, {
   }
 })
 ```
+
+### onInitError
+
+This option is a callback function that is executed if Keycloak initialisation has failed.
+
+The callback function has one parameter, which is the error object returned by Keycloak. Note that this may be undefined
+even though an error has occurred, as Keycloak does not return an error object in every error case.
 
 ## Examples
 

--- a/src/index.js
+++ b/src/index.js
@@ -73,6 +73,9 @@ function init (config, watch, options) {
   })
 
   keycloak.init(options.init)
+    .error(err => {
+      typeof options.onInitError === 'function' && options.onInitError(err)
+    })
   keycloak.onReady = function (authenticated) {
     updateWatchVariables(authenticated)
     watch.ready = true
@@ -127,7 +130,7 @@ function init (config, watch, options) {
 }
 
 function assertOptions (options) {
-  const {config, init, onReady} = options
+  const {config, init, onReady, onInitError} = options
   if (typeof config !== 'string' && !_isObject(config)) {
     return {hasError: true, error: `'config' option must be a string or an object. Found: '${config}'`}
   }
@@ -136,6 +139,9 @@ function assertOptions (options) {
   }
   if (onReady && typeof onReady !== 'function') {
     return {hasError: true, error: `'onReady' option must be a function. Found: '${onReady}'`}
+  }
+  if (onInitError && typeof onInitError !== 'function') {
+    return {hasError: true, error: `'onInitError' option must be a function. Found: '${onInitError}'`}
   }
   return {
     hasError: false,

--- a/src/index.js
+++ b/src/index.js
@@ -72,10 +72,6 @@ function init (config, watch, options) {
     cb && cb()
   })
 
-  keycloak.init(options.init)
-    .error(err => {
-      typeof options.onInitError === 'function' && options.onInitError(err)
-    })
   keycloak.onReady = function (authenticated) {
     updateWatchVariables(authenticated)
     watch.ready = true
@@ -95,6 +91,10 @@ function init (config, watch, options) {
   keycloak.onAuthRefreshSuccess = function () {
     updateWatchVariables(true)
   }
+  keycloak.init(options.init)
+    .error(err => {
+      typeof options.onInitError === 'function' && options.onInitError(err)
+    })
 
   function updateWatchVariables (isAuthenticated = false) {
     watch.authenticated = isAuthenticated


### PR DESCRIPTION
This lets the Vue application handle Keycloak initialization errors gracefully, rather than waiting for the onReady callback forever.