### PR TITLE
allow to use silentCheckSso feature of keycloak-js-8.0.0

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -49,14 +49,14 @@ export default {
         }
       }
     })
+    Object.defineProperty(Vue.prototype, '$keycloak', {
+      get () {
+        return watch
+      }
+    })
     getConfig(options.config)
       .then(config => {
         init(config, watch, options)
-        Object.defineProperty(Vue.prototype, '$keycloak', {
-          get () {
-            return watch
-          }
-        })
       })
       .catch(err => {
         console.log(err)

--- a/src/index.js
+++ b/src/index.js
@@ -91,6 +91,9 @@ function init (config, watch, options) {
   keycloak.onAuthRefreshSuccess = function () {
     updateWatchVariables(true)
   }
+  keycloak.onAuthLogout = function () {
+    updateWatchVariables(false)
+  }
   keycloak.init(options.init)
     .error(err => {
       typeof options.onInitError === 'function' && options.onInitError(err)


### PR DESCRIPTION
Keycloak javascript adapter can be initialized without redirect in the  main application window since 8.0.0 version. This feature allows to start Vue application before complete of keycloak initialization and handle misconfiguration or hard failures of keycloak server.
See details at the https://www.keycloak.org/docs/latest/securing_apps/index.html#_javascript_adapter

Example of application:
Initialization:
```
	Vue.use(VueKeyCloak, {
		config,
		init: {
			onLoad: 'check-sso',
			silentCheckSsoRedirectUri: window.location.origin + '/silent-check-sso.html'
		},
		onReady: (k: VueKeyCloakInstance) => {
			xhr.setToken(k.token);
		}
	});
	new Vue({
...
```
Navigation panel:
```
	<template v-if="!$keycloak.ready">
			<div class="user-info">
				<div class="second-row">
					<span class="company-info">{{$t('Connecting to SSO')}}</span>
					<FontAwesomeIcon class="icon" icon="spinner" />
				</div>
			</div>
		</template>
		<template v-if="$keycloak.ready">
			<div class="user-info" v-show="$keycloak.authenticated">
...
```