### PR TITLE
Some slight tweaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,9 +57,9 @@ Vue.use(VueKeyCloak, options)
 ```
 
 The plugin adds a `$keycloak` property to the global Vue instance.
-This is actually a new Vue instance and can be used as such.
-It shadows most of the keycloak instance's properties and functions,
-with the exception of the callback events, which the plugin needs to control itself.
+This is actually a [Vue.observable](https://vuejs.org/v2/api/#Vue-observable) instance and can be used as such.
+It shadows most of the keycloak instance's properties and functions. All other variables & functions can be found
+on `$keycloak.keycloak` attribute
 
 These properties/functions are exposed:
 
@@ -94,6 +94,7 @@ These properties/functions are exposed:
   hasResourceRole: Function,   // Keycloak hasResourceRole function
   token: String,               // The base64 encoded token that can be sent in the Authorization header in requests to services
   tokenParsed: String          // The parsed token as a JavaScript object
+  keycloak: Object             // The original keycloak instance 'as is' from keycloak-js adapter
 }
 ```
 
@@ -127,7 +128,7 @@ Currently, the plugin accepts a config object like this:
 **This will be deprecated in the next major release.**
 
 Thereafter, the config object, either returned from an endpoint (string) or
-set directly (object), must be compatible with the Keycloak JS adapter constructor arguments.
+set directly (object), must be compatible with the [Keycloak JS adapter](https://www.keycloak.org/docs/latest/securing_apps/#_javascript_adapter) constructor arguments.
 
 The `logoutRedirectUri` must instead be defined in [`options.logout`](#logout)
 
@@ -272,6 +273,21 @@ Remember; `login-required` is the default value for the onLoad property
 in the init object. So without passing an `init` object as argument, the default is
 `{ init: 'login-required' }`
 
+
+##### To avoid waiting for configuration endpoint before loading vue app:
+```javascript
+Vue.use(VueKeyCloak, {
+  init: {
+    onLoad: 'check-sso'
+  }
+})
+
+new Vue({
+  render: h => h(App)
+}).$mount('#app')
+```
+
+##### Wait until keycloak adapter is ready before loading vue app:
 ```javascript
 Vue.use(VueKeyCloak, {
   init: {

--- a/examples/README.md
+++ b/examples/README.md
@@ -5,7 +5,8 @@
 You must have a Keycloak server running somewhere, with the correct
 setup, eg. `redirectUri`, `clientId`, `realm` etc.
 
-This is beyond the scope of this example.
+Or you could run: `docker-compose up` in this directory and get a temporary working
+keycloak instance. You need to register a new user on the initial login
 
 ## Run the example
 

--- a/examples/docker-compose.yml
+++ b/examples/docker-compose.yml
@@ -1,0 +1,16 @@
+version: '3.7'
+
+services:
+
+  keycloak:
+    # Redhat-sso 7.4 uses keycloak 9.0.5. However that version does not have a docker tag. so using 9.0.3
+    # https://access.redhat.com/articles/2342881#rhsso74
+    image: jboss/keycloak:9.0.3
+    ports:
+      - "8085:8080"
+    environment:
+      KEYCLOAK_USER: admin
+      KEYCLOAK_PASSWORD: admin
+      KEYCLOAK_IMPORT: /tmp/vue_realm.json
+    volumes:
+      - "./vue_realm.json:/tmp/vue_realm.json"

--- a/examples/hello-keycloak/src/main.js
+++ b/examples/hello-keycloak/src/main.js
@@ -12,15 +12,14 @@ Vue.use(VueKeycloakJs, {
     onLoad: 'check-sso'
   },
   config: {
-    url: 'https://mykeycloak-server.com/auth',
-    clientId: 'MyClientId',
-    realm: 'MyRealm'
-  },
-  onReady: (keycloak) => {
-    new Vue({
-      router,
-      render: h => h(App)
-    }).$mount('#app')
+    url: 'http://localhost:8085/auth',
+    clientId: 'vue-client',
+    realm: 'vue'
   }
 })
+
+new Vue({
+  router,
+  render: h => h(App)
+}).$mount('#app')
 

--- a/examples/vue_realm.json
+++ b/examples/vue_realm.json
@@ -1,0 +1,1658 @@
+{
+  "id" : "vue",
+  "realm" : "vue",
+  "notBefore" : 0,
+  "revokeRefreshToken" : false,
+  "refreshTokenMaxReuse" : 0,
+  "accessTokenLifespan" : 300,
+  "accessTokenLifespanForImplicitFlow" : 900,
+  "ssoSessionIdleTimeout" : 1800,
+  "ssoSessionMaxLifespan" : 36000,
+  "ssoSessionIdleTimeoutRememberMe" : 0,
+  "ssoSessionMaxLifespanRememberMe" : 0,
+  "offlineSessionIdleTimeout" : 2592000,
+  "offlineSessionMaxLifespanEnabled" : false,
+  "offlineSessionMaxLifespan" : 5184000,
+  "accessCodeLifespan" : 60,
+  "accessCodeLifespanUserAction" : 300,
+  "accessCodeLifespanLogin" : 1800,
+  "actionTokenGeneratedByAdminLifespan" : 43200,
+  "actionTokenGeneratedByUserLifespan" : 300,
+  "enabled" : true,
+  "sslRequired" : "external",
+  "registrationAllowed" : true,
+  "registrationEmailAsUsername" : false,
+  "rememberMe" : false,
+  "verifyEmail" : false,
+  "loginWithEmailAllowed" : true,
+  "duplicateEmailsAllowed" : false,
+  "resetPasswordAllowed" : false,
+  "editUsernameAllowed" : false,
+  "bruteForceProtected" : false,
+  "permanentLockout" : false,
+  "maxFailureWaitSeconds" : 900,
+  "minimumQuickLoginWaitSeconds" : 60,
+  "waitIncrementSeconds" : 60,
+  "quickLoginCheckMilliSeconds" : 1000,
+  "maxDeltaTimeSeconds" : 43200,
+  "failureFactor" : 30,
+  "roles" : {
+    "realm" : [ {
+      "id" : "41c5c61b-a792-43e7-bc2a-47f32608a145",
+      "name" : "offline_access",
+      "description" : "${role_offline-access}",
+      "composite" : false,
+      "clientRole" : false,
+      "containerId" : "vue",
+      "attributes" : { }
+    }, {
+      "id" : "a2289e96-a4a3-42a9-8e08-b142bbd9058e",
+      "name" : "uma_authorization",
+      "description" : "${role_uma_authorization}",
+      "composite" : false,
+      "clientRole" : false,
+      "containerId" : "vue",
+      "attributes" : { }
+    } ],
+    "client" : {
+      "vue-client" : [ ],
+      "realm-management" : [ {
+        "id" : "ef590ee1-c240-4b69-8f9f-a36c11a7a1a1",
+        "name" : "view-realm",
+        "description" : "${role_view-realm}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "2c1fb00c-5391-49bb-8b09-477a5801f0d0",
+        "attributes" : { }
+      }, {
+        "id" : "8e3b588e-e4aa-49bf-b1e1-f3abe3edd517",
+        "name" : "view-clients",
+        "description" : "${role_view-clients}",
+        "composite" : true,
+        "composites" : {
+          "client" : {
+            "realm-management" : [ "query-clients" ]
+          }
+        },
+        "clientRole" : true,
+        "containerId" : "2c1fb00c-5391-49bb-8b09-477a5801f0d0",
+        "attributes" : { }
+      }, {
+        "id" : "b6ffb8b9-7b36-457e-b2a3-5ffc44388e45",
+        "name" : "manage-clients",
+        "description" : "${role_manage-clients}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "2c1fb00c-5391-49bb-8b09-477a5801f0d0",
+        "attributes" : { }
+      }, {
+        "id" : "1caa5566-bf60-495f-9633-38ccf0a9dea3",
+        "name" : "impersonation",
+        "description" : "${role_impersonation}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "2c1fb00c-5391-49bb-8b09-477a5801f0d0",
+        "attributes" : { }
+      }, {
+        "id" : "7879e6f5-2be6-4226-a4b7-395c9a6312b0",
+        "name" : "manage-authorization",
+        "description" : "${role_manage-authorization}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "2c1fb00c-5391-49bb-8b09-477a5801f0d0",
+        "attributes" : { }
+      }, {
+        "id" : "2e6f37f1-bf6f-4541-82d1-b58107490e7f",
+        "name" : "view-identity-providers",
+        "description" : "${role_view-identity-providers}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "2c1fb00c-5391-49bb-8b09-477a5801f0d0",
+        "attributes" : { }
+      }, {
+        "id" : "776d9170-033e-4765-ada0-4135ae909803",
+        "name" : "view-users",
+        "description" : "${role_view-users}",
+        "composite" : true,
+        "composites" : {
+          "client" : {
+            "realm-management" : [ "query-groups", "query-users" ]
+          }
+        },
+        "clientRole" : true,
+        "containerId" : "2c1fb00c-5391-49bb-8b09-477a5801f0d0",
+        "attributes" : { }
+      }, {
+        "id" : "ffbdf912-ab43-4900-8a9d-72684ba6cb64",
+        "name" : "query-realms",
+        "description" : "${role_query-realms}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "2c1fb00c-5391-49bb-8b09-477a5801f0d0",
+        "attributes" : { }
+      }, {
+        "id" : "b2f7c506-8c47-4d21-82c5-010644896747",
+        "name" : "manage-identity-providers",
+        "description" : "${role_manage-identity-providers}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "2c1fb00c-5391-49bb-8b09-477a5801f0d0",
+        "attributes" : { }
+      }, {
+        "id" : "52a9155b-9eba-4695-aa6b-2bf6ea3d8bf2",
+        "name" : "manage-realm",
+        "description" : "${role_manage-realm}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "2c1fb00c-5391-49bb-8b09-477a5801f0d0",
+        "attributes" : { }
+      }, {
+        "id" : "ea5d5f6a-f7af-4f05-97cf-16cedb819f04",
+        "name" : "query-clients",
+        "description" : "${role_query-clients}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "2c1fb00c-5391-49bb-8b09-477a5801f0d0",
+        "attributes" : { }
+      }, {
+        "id" : "a2f29625-a687-45d4-b510-2783e6d575f4",
+        "name" : "realm-admin",
+        "description" : "${role_realm-admin}",
+        "composite" : true,
+        "composites" : {
+          "client" : {
+            "realm-management" : [ "view-clients", "view-realm", "impersonation", "manage-clients", "manage-authorization", "view-identity-providers", "view-users", "query-realms", "manage-identity-providers", "manage-realm", "query-clients", "query-groups", "manage-events", "create-client", "query-users", "manage-users", "view-authorization", "view-events" ]
+          }
+        },
+        "clientRole" : true,
+        "containerId" : "2c1fb00c-5391-49bb-8b09-477a5801f0d0",
+        "attributes" : { }
+      }, {
+        "id" : "19424972-c775-49d8-9c13-bb00b58cb2ca",
+        "name" : "query-groups",
+        "description" : "${role_query-groups}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "2c1fb00c-5391-49bb-8b09-477a5801f0d0",
+        "attributes" : { }
+      }, {
+        "id" : "e3b64cdf-ec53-4ede-8a7f-fdb6b9ea3973",
+        "name" : "manage-events",
+        "description" : "${role_manage-events}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "2c1fb00c-5391-49bb-8b09-477a5801f0d0",
+        "attributes" : { }
+      }, {
+        "id" : "43c26a32-c6cd-4e33-bce7-9023c6bc815b",
+        "name" : "create-client",
+        "description" : "${role_create-client}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "2c1fb00c-5391-49bb-8b09-477a5801f0d0",
+        "attributes" : { }
+      }, {
+        "id" : "1ed1f099-15b6-48d8-9d1b-c7680e0972c0",
+        "name" : "query-users",
+        "description" : "${role_query-users}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "2c1fb00c-5391-49bb-8b09-477a5801f0d0",
+        "attributes" : { }
+      }, {
+        "id" : "28b31103-9bb1-40c0-8813-b1c40f625be1",
+        "name" : "manage-users",
+        "description" : "${role_manage-users}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "2c1fb00c-5391-49bb-8b09-477a5801f0d0",
+        "attributes" : { }
+      }, {
+        "id" : "85e1099d-efb4-4f66-9d49-a5aa672a6fa6",
+        "name" : "view-authorization",
+        "description" : "${role_view-authorization}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "2c1fb00c-5391-49bb-8b09-477a5801f0d0",
+        "attributes" : { }
+      }, {
+        "id" : "65a55dc2-f451-458b-8705-6e311a754d9d",
+        "name" : "view-events",
+        "description" : "${role_view-events}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "2c1fb00c-5391-49bb-8b09-477a5801f0d0",
+        "attributes" : { }
+      } ],
+      "security-admin-console" : [ ],
+      "admin-cli" : [ ],
+      "account-console" : [ ],
+      "broker" : [ {
+        "id" : "0dceefe4-81ee-45eb-a7b2-39da1d1ffe95",
+        "name" : "read-token",
+        "description" : "${role_read-token}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "32cb3ded-a460-4faa-8dbd-da3033d1cde2",
+        "attributes" : { }
+      } ],
+      "account" : [ {
+        "id" : "f9916a3e-8532-4081-839c-2ca6dc371564",
+        "name" : "manage-account-links",
+        "description" : "${role_manage-account-links}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "b4deb352-e0d4-40d4-b2b2-21f7aec7a4b3",
+        "attributes" : { }
+      }, {
+        "id" : "aa9987e5-6516-40b0-84f4-6b5ee5dbf6c7",
+        "name" : "view-applications",
+        "description" : "${role_view-applications}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "b4deb352-e0d4-40d4-b2b2-21f7aec7a4b3",
+        "attributes" : { }
+      }, {
+        "id" : "55d668cb-2bab-431b-9514-b1a418c22c4c",
+        "name" : "view-consent",
+        "description" : "${role_view-consent}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "b4deb352-e0d4-40d4-b2b2-21f7aec7a4b3",
+        "attributes" : { }
+      }, {
+        "id" : "1fba8480-cfc4-45f6-8729-fe9d93bc312e",
+        "name" : "manage-account",
+        "description" : "${role_manage-account}",
+        "composite" : true,
+        "composites" : {
+          "client" : {
+            "account" : [ "manage-account-links" ]
+          }
+        },
+        "clientRole" : true,
+        "containerId" : "b4deb352-e0d4-40d4-b2b2-21f7aec7a4b3",
+        "attributes" : { }
+      }, {
+        "id" : "11ac0928-8114-41b5-9545-9d5976f29058",
+        "name" : "view-profile",
+        "description" : "${role_view-profile}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "b4deb352-e0d4-40d4-b2b2-21f7aec7a4b3",
+        "attributes" : { }
+      }, {
+        "id" : "9a2715b1-3798-42f1-b40c-2f5c457ea70e",
+        "name" : "manage-consent",
+        "description" : "${role_manage-consent}",
+        "composite" : true,
+        "composites" : {
+          "client" : {
+            "account" : [ "view-consent" ]
+          }
+        },
+        "clientRole" : true,
+        "containerId" : "b4deb352-e0d4-40d4-b2b2-21f7aec7a4b3",
+        "attributes" : { }
+      } ]
+    }
+  },
+  "groups" : [ ],
+  "defaultRoles" : [ "offline_access", "uma_authorization" ],
+  "requiredCredentials" : [ "password" ],
+  "otpPolicyType" : "totp",
+  "otpPolicyAlgorithm" : "HmacSHA1",
+  "otpPolicyInitialCounter" : 0,
+  "otpPolicyDigits" : 6,
+  "otpPolicyLookAheadWindow" : 1,
+  "otpPolicyPeriod" : 30,
+  "otpSupportedApplications" : [ "FreeOTP", "Google Authenticator" ],
+  "webAuthnPolicyRpEntityName" : "keycloak",
+  "webAuthnPolicySignatureAlgorithms" : [ "ES256" ],
+  "webAuthnPolicyRpId" : "",
+  "webAuthnPolicyAttestationConveyancePreference" : "not specified",
+  "webAuthnPolicyAuthenticatorAttachment" : "not specified",
+  "webAuthnPolicyRequireResidentKey" : "not specified",
+  "webAuthnPolicyUserVerificationRequirement" : "not specified",
+  "webAuthnPolicyCreateTimeout" : 0,
+  "webAuthnPolicyAvoidSameAuthenticatorRegister" : false,
+  "webAuthnPolicyAcceptableAaguids" : [ ],
+  "webAuthnPolicyPasswordlessRpEntityName" : "keycloak",
+  "webAuthnPolicyPasswordlessSignatureAlgorithms" : [ "ES256" ],
+  "webAuthnPolicyPasswordlessRpId" : "",
+  "webAuthnPolicyPasswordlessAttestationConveyancePreference" : "not specified",
+  "webAuthnPolicyPasswordlessAuthenticatorAttachment" : "not specified",
+  "webAuthnPolicyPasswordlessRequireResidentKey" : "not specified",
+  "webAuthnPolicyPasswordlessUserVerificationRequirement" : "not specified",
+  "webAuthnPolicyPasswordlessCreateTimeout" : 0,
+  "webAuthnPolicyPasswordlessAvoidSameAuthenticatorRegister" : false,
+  "webAuthnPolicyPasswordlessAcceptableAaguids" : [ ],
+  "scopeMappings" : [ {
+    "clientScope" : "offline_access",
+    "roles" : [ "offline_access" ]
+  } ],
+  "clientScopeMappings" : {
+    "account" : [ {
+      "client" : "account-console",
+      "roles" : [ "manage-account" ]
+    } ]
+  },
+  "clients" : [ {
+    "id" : "b4deb352-e0d4-40d4-b2b2-21f7aec7a4b3",
+    "clientId" : "account",
+    "name" : "${client_account}",
+    "rootUrl" : "${authBaseUrl}",
+    "baseUrl" : "/realms/vue/account/",
+    "surrogateAuthRequired" : false,
+    "enabled" : true,
+    "alwaysDisplayInConsole" : false,
+    "clientAuthenticatorType" : "client-secret",
+    "secret" : "0a713b47-a863-4440-90ea-8b4c40b12921",
+    "defaultRoles" : [ "view-profile", "manage-account" ],
+    "redirectUris" : [ "/realms/vue/account/*" ],
+    "webOrigins" : [ ],
+    "notBefore" : 0,
+    "bearerOnly" : false,
+    "consentRequired" : false,
+    "standardFlowEnabled" : true,
+    "implicitFlowEnabled" : false,
+    "directAccessGrantsEnabled" : false,
+    "serviceAccountsEnabled" : false,
+    "publicClient" : false,
+    "frontchannelLogout" : false,
+    "protocol" : "openid-connect",
+    "attributes" : { },
+    "authenticationFlowBindingOverrides" : { },
+    "fullScopeAllowed" : false,
+    "nodeReRegistrationTimeout" : 0,
+    "defaultClientScopes" : [ "web-origins", "role_list", "roles", "profile", "email" ],
+    "optionalClientScopes" : [ "address", "phone", "offline_access", "microprofile-jwt" ]
+  }, {
+    "id" : "ec3be2a2-20a7-4f74-9552-473ae2d2f95d",
+    "clientId" : "account-console",
+    "name" : "${client_account-console}",
+    "rootUrl" : "${authBaseUrl}",
+    "baseUrl" : "/realms/vue/account/",
+    "surrogateAuthRequired" : false,
+    "enabled" : true,
+    "alwaysDisplayInConsole" : false,
+    "clientAuthenticatorType" : "client-secret",
+    "secret" : "8123f29d-0171-4df3-964f-178ba9b5ec87",
+    "redirectUris" : [ "/realms/vue/account/*" ],
+    "webOrigins" : [ ],
+    "notBefore" : 0,
+    "bearerOnly" : false,
+    "consentRequired" : false,
+    "standardFlowEnabled" : true,
+    "implicitFlowEnabled" : false,
+    "directAccessGrantsEnabled" : false,
+    "serviceAccountsEnabled" : false,
+    "publicClient" : true,
+    "frontchannelLogout" : false,
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "pkce.code.challenge.method" : "S256"
+    },
+    "authenticationFlowBindingOverrides" : { },
+    "fullScopeAllowed" : false,
+    "nodeReRegistrationTimeout" : 0,
+    "protocolMappers" : [ {
+      "id" : "6249441e-d1a4-4b5c-9d70-1c9403ac8267",
+      "name" : "audience resolve",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-audience-resolve-mapper",
+      "consentRequired" : false,
+      "config" : { }
+    } ],
+    "defaultClientScopes" : [ "web-origins", "role_list", "roles", "profile", "email" ],
+    "optionalClientScopes" : [ "address", "phone", "offline_access", "microprofile-jwt" ]
+  }, {
+    "id" : "a5082918-9433-4cdd-83d8-cb12eb3dd1d7",
+    "clientId" : "admin-cli",
+    "name" : "${client_admin-cli}",
+    "surrogateAuthRequired" : false,
+    "enabled" : true,
+    "alwaysDisplayInConsole" : false,
+    "clientAuthenticatorType" : "client-secret",
+    "secret" : "3f0be167-9062-4f8c-b60d-b07121850c08",
+    "redirectUris" : [ ],
+    "webOrigins" : [ ],
+    "notBefore" : 0,
+    "bearerOnly" : false,
+    "consentRequired" : false,
+    "standardFlowEnabled" : false,
+    "implicitFlowEnabled" : false,
+    "directAccessGrantsEnabled" : true,
+    "serviceAccountsEnabled" : false,
+    "publicClient" : true,
+    "frontchannelLogout" : false,
+    "protocol" : "openid-connect",
+    "attributes" : { },
+    "authenticationFlowBindingOverrides" : { },
+    "fullScopeAllowed" : false,
+    "nodeReRegistrationTimeout" : 0,
+    "defaultClientScopes" : [ "web-origins", "role_list", "roles", "profile", "email" ],
+    "optionalClientScopes" : [ "address", "phone", "offline_access", "microprofile-jwt" ]
+  }, {
+    "id" : "32cb3ded-a460-4faa-8dbd-da3033d1cde2",
+    "clientId" : "broker",
+    "name" : "${client_broker}",
+    "surrogateAuthRequired" : false,
+    "enabled" : true,
+    "alwaysDisplayInConsole" : false,
+    "clientAuthenticatorType" : "client-secret",
+    "secret" : "13b41959-7410-4b7c-801f-246817b8e344",
+    "redirectUris" : [ ],
+    "webOrigins" : [ ],
+    "notBefore" : 0,
+    "bearerOnly" : false,
+    "consentRequired" : false,
+    "standardFlowEnabled" : true,
+    "implicitFlowEnabled" : false,
+    "directAccessGrantsEnabled" : false,
+    "serviceAccountsEnabled" : false,
+    "publicClient" : false,
+    "frontchannelLogout" : false,
+    "protocol" : "openid-connect",
+    "attributes" : { },
+    "authenticationFlowBindingOverrides" : { },
+    "fullScopeAllowed" : false,
+    "nodeReRegistrationTimeout" : 0,
+    "defaultClientScopes" : [ "web-origins", "role_list", "roles", "profile", "email" ],
+    "optionalClientScopes" : [ "address", "phone", "offline_access", "microprofile-jwt" ]
+  }, {
+    "id" : "2c1fb00c-5391-49bb-8b09-477a5801f0d0",
+    "clientId" : "realm-management",
+    "name" : "${client_realm-management}",
+    "surrogateAuthRequired" : false,
+    "enabled" : true,
+    "alwaysDisplayInConsole" : false,
+    "clientAuthenticatorType" : "client-secret",
+    "secret" : "7f9474d5-d506-4887-8585-96c05d277c08",
+    "redirectUris" : [ ],
+    "webOrigins" : [ ],
+    "notBefore" : 0,
+    "bearerOnly" : true,
+    "consentRequired" : false,
+    "standardFlowEnabled" : true,
+    "implicitFlowEnabled" : false,
+    "directAccessGrantsEnabled" : false,
+    "serviceAccountsEnabled" : false,
+    "publicClient" : false,
+    "frontchannelLogout" : false,
+    "protocol" : "openid-connect",
+    "attributes" : { },
+    "authenticationFlowBindingOverrides" : { },
+    "fullScopeAllowed" : false,
+    "nodeReRegistrationTimeout" : 0,
+    "defaultClientScopes" : [ "web-origins", "role_list", "roles", "profile", "email" ],
+    "optionalClientScopes" : [ "address", "phone", "offline_access", "microprofile-jwt" ]
+  }, {
+    "id" : "a41b1458-0e5a-4516-b694-24317b964835",
+    "clientId" : "security-admin-console",
+    "name" : "${client_security-admin-console}",
+    "rootUrl" : "${authAdminUrl}",
+    "baseUrl" : "/admin/vue/console/",
+    "surrogateAuthRequired" : false,
+    "enabled" : true,
+    "alwaysDisplayInConsole" : false,
+    "clientAuthenticatorType" : "client-secret",
+    "secret" : "c0f3451d-c83d-41d7-bd92-19b52393fe44",
+    "redirectUris" : [ "/admin/vue/console/*" ],
+    "webOrigins" : [ "+" ],
+    "notBefore" : 0,
+    "bearerOnly" : false,
+    "consentRequired" : false,
+    "standardFlowEnabled" : true,
+    "implicitFlowEnabled" : false,
+    "directAccessGrantsEnabled" : false,
+    "serviceAccountsEnabled" : false,
+    "publicClient" : true,
+    "frontchannelLogout" : false,
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "pkce.code.challenge.method" : "S256"
+    },
+    "authenticationFlowBindingOverrides" : { },
+    "fullScopeAllowed" : false,
+    "nodeReRegistrationTimeout" : 0,
+    "protocolMappers" : [ {
+      "id" : "26a6aa18-158a-489f-bdcb-38b7af7d4e5c",
+      "name" : "locale",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "locale",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "locale",
+        "jsonType.label" : "String"
+      }
+    } ],
+    "defaultClientScopes" : [ "web-origins", "role_list", "roles", "profile", "email" ],
+    "optionalClientScopes" : [ "address", "phone", "offline_access", "microprofile-jwt" ]
+  }, {
+    "id" : "701e4db3-feed-4bc6-9826-a6ba66a87eeb",
+    "clientId" : "vue-client",
+    "surrogateAuthRequired" : false,
+    "enabled" : true,
+    "alwaysDisplayInConsole" : false,
+    "clientAuthenticatorType" : "client-secret",
+    "secret" : "7377bf37-6827-4a0d-b1d9-f1969c8c4388",
+    "redirectUris" : [ "http://localhost:8080/*" ],
+    "webOrigins" : [ "http://localhost:8080" ],
+    "notBefore" : 0,
+    "bearerOnly" : false,
+    "consentRequired" : false,
+    "standardFlowEnabled" : true,
+    "implicitFlowEnabled" : false,
+    "directAccessGrantsEnabled" : true,
+    "serviceAccountsEnabled" : false,
+    "publicClient" : true,
+    "frontchannelLogout" : false,
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "saml.assertion.signature" : "false",
+      "saml.force.post.binding" : "false",
+      "saml.multivalued.roles" : "false",
+      "saml.encrypt" : "false",
+      "saml.server.signature" : "false",
+      "saml.server.signature.keyinfo.ext" : "false",
+      "exclude.session.state.from.auth.response" : "false",
+      "saml_force_name_id_format" : "false",
+      "saml.client.signature" : "false",
+      "tls.client.certificate.bound.access.tokens" : "false",
+      "saml.authnstatement" : "false",
+      "display.on.consent.screen" : "false",
+      "saml.onetimeuse.condition" : "false"
+    },
+    "authenticationFlowBindingOverrides" : { },
+    "fullScopeAllowed" : true,
+    "nodeReRegistrationTimeout" : -1,
+    "defaultClientScopes" : [ "web-origins", "role_list", "roles", "profile", "email" ],
+    "optionalClientScopes" : [ "address", "phone", "offline_access", "microprofile-jwt" ]
+  } ],
+  "clientScopes" : [ {
+    "id" : "9890362a-353c-4a69-ad08-41ff9e649959",
+    "name" : "address",
+    "description" : "OpenID Connect built-in scope: address",
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "include.in.token.scope" : "true",
+      "display.on.consent.screen" : "true",
+      "consent.screen.text" : "${addressScopeConsentText}"
+    },
+    "protocolMappers" : [ {
+      "id" : "91e7030d-a7cd-4d25-ab09-0bd8dae76528",
+      "name" : "address",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-address-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "user.attribute.formatted" : "formatted",
+        "user.attribute.country" : "country",
+        "user.attribute.postal_code" : "postal_code",
+        "userinfo.token.claim" : "true",
+        "user.attribute.street" : "street",
+        "id.token.claim" : "true",
+        "user.attribute.region" : "region",
+        "access.token.claim" : "true",
+        "user.attribute.locality" : "locality"
+      }
+    } ]
+  }, {
+    "id" : "132b9135-d6e0-40cf-9a7c-5723b5975113",
+    "name" : "email",
+    "description" : "OpenID Connect built-in scope: email",
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "include.in.token.scope" : "true",
+      "display.on.consent.screen" : "true",
+      "consent.screen.text" : "${emailScopeConsentText}"
+    },
+    "protocolMappers" : [ {
+      "id" : "c59c656f-8c4b-4da2-8fcb-2e2e65858223",
+      "name" : "email verified",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-property-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "emailVerified",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "email_verified",
+        "jsonType.label" : "boolean"
+      }
+    }, {
+      "id" : "af7faa17-44c5-4cfb-9e39-3da61d4f6722",
+      "name" : "email",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-property-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "email",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "email",
+        "jsonType.label" : "String"
+      }
+    } ]
+  }, {
+    "id" : "17e54539-1c12-4da6-aa41-1b855692a8a9",
+    "name" : "microprofile-jwt",
+    "description" : "Microprofile - JWT built-in scope",
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "include.in.token.scope" : "true",
+      "display.on.consent.screen" : "false"
+    },
+    "protocolMappers" : [ {
+      "id" : "85637d27-f695-48af-af0f-012931e549cb",
+      "name" : "upn",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-property-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "username",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "upn",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "965894fe-5b8d-4c2b-91b0-35fba8b9044d",
+      "name" : "groups",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-realm-role-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "multivalued" : "true",
+        "user.attribute" : "foo",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "groups",
+        "jsonType.label" : "String"
+      }
+    } ]
+  }, {
+    "id" : "e39c2315-0f98-4edd-8a90-0806e6c13ba8",
+    "name" : "offline_access",
+    "description" : "OpenID Connect built-in scope: offline_access",
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "consent.screen.text" : "${offlineAccessScopeConsentText}",
+      "display.on.consent.screen" : "true"
+    }
+  }, {
+    "id" : "8b1dcdbd-7415-4fc8-bfe6-985df7efdc51",
+    "name" : "phone",
+    "description" : "OpenID Connect built-in scope: phone",
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "include.in.token.scope" : "true",
+      "display.on.consent.screen" : "true",
+      "consent.screen.text" : "${phoneScopeConsentText}"
+    },
+    "protocolMappers" : [ {
+      "id" : "b7638c8e-5aeb-476a-8740-36ecb3224377",
+      "name" : "phone number verified",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "phoneNumberVerified",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "phone_number_verified",
+        "jsonType.label" : "boolean"
+      }
+    }, {
+      "id" : "7a4d2aea-6098-4157-9561-d640d2489c76",
+      "name" : "phone number",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "phoneNumber",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "phone_number",
+        "jsonType.label" : "String"
+      }
+    } ]
+  }, {
+    "id" : "6348c6e0-7068-4ca2-bd71-f2f4cd04afae",
+    "name" : "profile",
+    "description" : "OpenID Connect built-in scope: profile",
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "include.in.token.scope" : "true",
+      "display.on.consent.screen" : "true",
+      "consent.screen.text" : "${profileScopeConsentText}"
+    },
+    "protocolMappers" : [ {
+      "id" : "c214b217-9790-4e52-ae03-c3e98db3d574",
+      "name" : "nickname",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "nickname",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "nickname",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "10c772c6-63f3-44bc-ad39-860204d1f553",
+      "name" : "picture",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "picture",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "picture",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "cfb0291c-9d27-4a19-9008-e7012a814c59",
+      "name" : "gender",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "gender",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "gender",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "c3c91a68-3112-407b-99b5-31f66c5cf5e9",
+      "name" : "family name",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-property-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "lastName",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "family_name",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "450e3013-4dd5-4cc5-a28e-33041f1203a1",
+      "name" : "profile",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "profile",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "profile",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "67f9e83f-a264-4960-9a25-41d2e066ea7b",
+      "name" : "birthdate",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "birthdate",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "birthdate",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "c9317620-78a9-4c57-8f1c-ca2bbd18dae1",
+      "name" : "updated at",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "updatedAt",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "updated_at",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "dbf04151-2388-4393-87a8-8e268d2e5ac0",
+      "name" : "zoneinfo",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "zoneinfo",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "zoneinfo",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "186cba69-0d0c-42de-918e-70d5782d030f",
+      "name" : "website",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "website",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "website",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "8ff94355-3371-419d-a848-0a34580113c0",
+      "name" : "given name",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-property-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "firstName",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "given_name",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "4df71968-f25c-452f-924f-b791f4ab2a7c",
+      "name" : "full name",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-full-name-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "userinfo.token.claim" : "true"
+      }
+    }, {
+      "id" : "649711ae-813a-4785-96e0-7cf575c3e05d",
+      "name" : "username",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-property-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "username",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "preferred_username",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "fb302080-045e-4c9f-ab91-b2f6ee1a1b05",
+      "name" : "middle name",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "middleName",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "middle_name",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "454a01da-6a4f-4c4b-82bf-561b5b0c42f9",
+      "name" : "locale",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "locale",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "locale",
+        "jsonType.label" : "String"
+      }
+    } ]
+  }, {
+    "id" : "6a35dace-9734-4970-b08e-dedc8c120ca7",
+    "name" : "role_list",
+    "description" : "SAML role list",
+    "protocol" : "saml",
+    "attributes" : {
+      "consent.screen.text" : "${samlRoleListScopeConsentText}",
+      "display.on.consent.screen" : "true"
+    },
+    "protocolMappers" : [ {
+      "id" : "1035011d-7787-4297-ac93-f39da0ecdd66",
+      "name" : "role list",
+      "protocol" : "saml",
+      "protocolMapper" : "saml-role-list-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "single" : "false",
+        "attribute.nameformat" : "Basic",
+        "attribute.name" : "Role"
+      }
+    } ]
+  }, {
+    "id" : "190a4f20-6db7-4c87-b2a6-93e4cf5f3f2e",
+    "name" : "roles",
+    "description" : "OpenID Connect scope for add user roles to the access token",
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "include.in.token.scope" : "false",
+      "display.on.consent.screen" : "true",
+      "consent.screen.text" : "${rolesScopeConsentText}"
+    },
+    "protocolMappers" : [ {
+      "id" : "4dce4bdd-f7d2-4b41-b260-6cb398e2051d",
+      "name" : "realm roles",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-realm-role-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "user.attribute" : "foo",
+        "access.token.claim" : "true",
+        "claim.name" : "realm_access.roles",
+        "jsonType.label" : "String",
+        "multivalued" : "true"
+      }
+    }, {
+      "id" : "5e6aa753-e16f-4233-ba4b-df44798cd89c",
+      "name" : "client roles",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-client-role-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "user.attribute" : "foo",
+        "access.token.claim" : "true",
+        "claim.name" : "resource_access.${client_id}.roles",
+        "jsonType.label" : "String",
+        "multivalued" : "true"
+      }
+    }, {
+      "id" : "c4eccbe4-0882-4072-9a9d-a47cbd923b4b",
+      "name" : "audience resolve",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-audience-resolve-mapper",
+      "consentRequired" : false,
+      "config" : { }
+    } ]
+  }, {
+    "id" : "c644ffe6-e8cd-4f00-85a6-d002ff4e9aea",
+    "name" : "web-origins",
+    "description" : "OpenID Connect scope for add allowed web origins to the access token",
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "include.in.token.scope" : "false",
+      "display.on.consent.screen" : "false",
+      "consent.screen.text" : ""
+    },
+    "protocolMappers" : [ {
+      "id" : "975e76fb-3c76-4576-9bba-c6d97528cc32",
+      "name" : "allowed web origins",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-allowed-origins-mapper",
+      "consentRequired" : false,
+      "config" : { }
+    } ]
+  } ],
+  "defaultDefaultClientScopes" : [ "email", "roles", "profile", "role_list", "web-origins" ],
+  "defaultOptionalClientScopes" : [ "microprofile-jwt", "phone", "address", "offline_access" ],
+  "browserSecurityHeaders" : {
+    "contentSecurityPolicyReportOnly" : "",
+    "xContentTypeOptions" : "nosniff",
+    "xRobotsTag" : "none",
+    "xFrameOptions" : "SAMEORIGIN",
+    "contentSecurityPolicy" : "frame-src 'self'; frame-ancestors 'self'; object-src 'none';",
+    "xXSSProtection" : "1; mode=block",
+    "strictTransportSecurity" : "max-age=31536000; includeSubDomains"
+  },
+  "smtpServer" : { },
+  "eventsEnabled" : false,
+  "eventsListeners" : [ "jboss-logging" ],
+  "enabledEventTypes" : [ ],
+  "adminEventsEnabled" : false,
+  "adminEventsDetailsEnabled" : false,
+  "components" : {
+    "org.keycloak.services.clientregistration.policy.ClientRegistrationPolicy" : [ {
+      "id" : "0808cec8-ef6f-48b3-b789-8e833a8b59a8",
+      "name" : "Consent Required",
+      "providerId" : "consent-required",
+      "subType" : "anonymous",
+      "subComponents" : { },
+      "config" : { }
+    }, {
+      "id" : "ccb6725a-eae8-4287-b057-c6d14cea0017",
+      "name" : "Allowed Protocol Mapper Types",
+      "providerId" : "allowed-protocol-mappers",
+      "subType" : "anonymous",
+      "subComponents" : { },
+      "config" : {
+        "allowed-protocol-mapper-types" : [ "oidc-usermodel-attribute-mapper", "oidc-full-name-mapper", "saml-user-property-mapper", "saml-role-list-mapper", "saml-user-attribute-mapper", "oidc-usermodel-property-mapper", "oidc-address-mapper", "oidc-sha256-pairwise-sub-mapper" ]
+      }
+    }, {
+      "id" : "eca0dacf-7405-46f8-99ba-9a13191b5801",
+      "name" : "Allowed Client Scopes",
+      "providerId" : "allowed-client-templates",
+      "subType" : "anonymous",
+      "subComponents" : { },
+      "config" : {
+        "allow-default-scopes" : [ "true" ]
+      }
+    }, {
+      "id" : "027e7282-33b9-4f62-8393-3b9973925ff0",
+      "name" : "Allowed Protocol Mapper Types",
+      "providerId" : "allowed-protocol-mappers",
+      "subType" : "authenticated",
+      "subComponents" : { },
+      "config" : {
+        "allowed-protocol-mapper-types" : [ "oidc-address-mapper", "saml-user-property-mapper", "oidc-sha256-pairwise-sub-mapper", "saml-user-attribute-mapper", "oidc-usermodel-attribute-mapper", "oidc-usermodel-property-mapper", "oidc-full-name-mapper", "saml-role-list-mapper" ]
+      }
+    }, {
+      "id" : "ba08f0f8-22ea-4ded-809e-4bc2b07afb84",
+      "name" : "Full Scope Disabled",
+      "providerId" : "scope",
+      "subType" : "anonymous",
+      "subComponents" : { },
+      "config" : { }
+    }, {
+      "id" : "36f0140e-fdcf-49bc-996a-47f80b28ebfd",
+      "name" : "Trusted Hosts",
+      "providerId" : "trusted-hosts",
+      "subType" : "anonymous",
+      "subComponents" : { },
+      "config" : {
+        "host-sending-registration-request-must-match" : [ "true" ],
+        "client-uris-must-match" : [ "true" ]
+      }
+    }, {
+      "id" : "34821355-7a76-47db-b83b-64035b14c173",
+      "name" : "Max Clients Limit",
+      "providerId" : "max-clients",
+      "subType" : "anonymous",
+      "subComponents" : { },
+      "config" : {
+        "max-clients" : [ "200" ]
+      }
+    }, {
+      "id" : "43da0350-e14c-46ad-b2db-5b51842c1e6a",
+      "name" : "Allowed Client Scopes",
+      "providerId" : "allowed-client-templates",
+      "subType" : "authenticated",
+      "subComponents" : { },
+      "config" : {
+        "allow-default-scopes" : [ "true" ]
+      }
+    } ],
+    "org.keycloak.keys.KeyProvider" : [ {
+      "id" : "e5b32c26-88cf-4700-9d33-5b42e5d99a4b",
+      "name" : "aes-generated",
+      "providerId" : "aes-generated",
+      "subComponents" : { },
+      "config" : {
+        "kid" : [ "c731faa8-45b0-47ad-9fa4-7585d9a461c1" ],
+        "secret" : [ "Ev-_HgxKK7ZdmtABDjjsrQ" ],
+        "priority" : [ "100" ]
+      }
+    }, {
+      "id" : "ee3e52e0-022c-4b1c-94fe-e45573e96420",
+      "name" : "rsa-generated",
+      "providerId" : "rsa-generated",
+      "subComponents" : { },
+      "config" : {
+        "privateKey" : [ "MIIEowIBAAKCAQEAiwtJ4KRBLCg8bUal2VG11W2ZHb0ZCOSM1u/T+xi/AOLxDU0jkP7rhMCBloXPtAYqQzzvW59nCdRK35VoAZo3T92hAreBANc3pgRfWaynYmGvj0onKKi0rlXsEC0hkBHKna8WnTqS2Vgai2P3y2YcskcfGG6GV57xvwwotHF0m2+lrC6MNFwAQV3GjmHMkBPwvstgrkRyslHn9WPR8SHLglCEsTQpi24T+6bfca+oGhSEraG5NsN8rYcb9SQSL8IDpZ35JlZK/XMMlxj+RJNNz6Da0fVFfEcq33pkfZ0lvP/cqmTTNeyRgyDOz2jO/rhNLKvz3spJuxRPARpP96MXXwIDAQABAoIBAGbIEHNjV93JXGm2yJAti4laO84041WkhMu5euxpLX/9Qg0AEaN0HSsDlodrIM9Fo2YSnCkRWvx0FmjSK5DLq8l43jWA6nZxoOwy3T0PmKfr5/e2691tYCpiz15hziaOUEVhkQjmrHjHXM/fNOQA9oN+eWj5Aouwraj41voTyAvBUtGIqWfA4glcL6Le07V5q40+0e1K1vtuokQVqTWE0C+TcL4eJA3PHoe4TmLSO2PiUmtGUnCc9Q5o9LewVIb0C+lRFAUDlVtg6uZu11wnSUEoc8xxBfDwbssLHJHVZjSqdT2fqjPnBbhCQV3B2NMaL7MXW2vTtjC+veQQWtTxiSECgYEA0KKR7/HRjISE/rWezHNj3gJoKJuHQ+VryVlgSl1y+xKZyJKdVxZonV0UxyWvqezkdxtuUkeY9+dzQ60PDIw0CJx7G855bzrre90DUAQ9oPHJQ4tqzkxSLgc6HAZc1HdPSgZuK9ksJARj2YTdRz/mUqJLFM/MDcombN6hcp4beg8CgYEAqpw9OnMnvzkmM5rQ8rLkqwlQqNXPzwUt3zmoHTvbYkg94rE25P6uzxSF+43+LIe4eNW3BU5swnds3/IcYyN4PHr4uF+bPEoHe2GvLRNYe//5q30c/OGkG2AJwC14rhi+LjSxC0U4JCb1xE+AKRpjJAAB8NAf49lFhq33h+kwHbECgYBD8372mFr4mjy6vKqQylBPgZctCqK+oV0+wgZTkiYd0gwWQHJQZ/MAtc1Lo2GYRZiPlnaTA9C1hUOMWjQZkRxtZZHPF6uDZ7xEplIq4Ia2Aancfu71a/QkG6R4djYL2SQQ5xFA5MW0oV1n/hcX2p8IcOVlTNyX7Swgr04EB6zJTwKBgFHsFeZ0FxjWK0bKRxzS08RhA68eg9uHRCCVAemPrWdDAxxQNei9dlkPJMrGws7FGMpE7M4Ke2ThjZD3I7Ri+sAn2DhICDVp4q/XFxOQ34MjRdKXkAzJmFBgzC3QZ8tJLEDpoj2kLjIF1ys9dW/HMOW/by8f8MAquxzRejNzwFvxAoGBAMael+B9Tg10V3ZyQg9iW9SdQVm11bVGXtI0jt5hG30ZosMBBm3TiEBG95Fm6aZUit2ic97ZAUGInUujMC6GXKC8pAL2Q7cfjwTfdyCfAOG0ZLLwdWBYLCNMZLlRljyLxucPECn7Fi8jhC0So/qn5yCB2ACQfKcA+wFGsAtQo4oO" ],
+        "certificate" : [ "MIIClTCCAX0CBgF1Y8abizANBgkqhkiG9w0BAQsFADAOMQwwCgYDVQQDDAN2dWUwHhcNMjAxMDI2MDcxNzQxWhcNMzAxMDI2MDcxOTIxWjAOMQwwCgYDVQQDDAN2dWUwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCLC0ngpEEsKDxtRqXZUbXVbZkdvRkI5IzW79P7GL8A4vENTSOQ/uuEwIGWhc+0BipDPO9bn2cJ1ErflWgBmjdP3aECt4EA1zemBF9ZrKdiYa+PSicoqLSuVewQLSGQEcqdrxadOpLZWBqLY/fLZhyyRx8YboZXnvG/DCi0cXSbb6WsLow0XABBXcaOYcyQE/C+y2CuRHKyUef1Y9HxIcuCUISxNCmLbhP7pt9xr6gaFIStobk2w3ythxv1JBIvwgOlnfkmVkr9cwyXGP5Ek03PoNrR9UV8RyrfemR9nSW8/9yqZNM17JGDIM7PaM7+uE0sq/Peykm7FE8BGk/3oxdfAgMBAAEwDQYJKoZIhvcNAQELBQADggEBAFD62tCX7iyqHD7rV0ec4geIgT5Dsxb73UqZvQObHB8zhx7OcQR5/aRbU9JYxSfsfHi/bzokv6Xk3C5qtWziCtY1M/x65h7uY507WfjVPTlLGasdA2+B6Dlqssd5ObhJIOE21h0Ou92w490jjknvjineCqyDy4VRkOoGpoc/3hLjbNy698EOGMiVz7A+P4zDKPdDPYYPIRwLJ8PxMHovONkWIjP6hJ3yCuytQjxj5mGKyI3E5E/zSWrXVcGU5YW/jROJxaZNm58yIiEfYN6hPNZk0bCofVy/FBLSuH7lCEZFMd1jBgTEeDddGkoFYxM0fGzQf2ef9l1YacPgL5kT9As=" ],
+        "priority" : [ "100" ]
+      }
+    }, {
+      "id" : "9aeb5cf9-6ea3-497c-b9b6-313549f956f8",
+      "name" : "hmac-generated",
+      "providerId" : "hmac-generated",
+      "subComponents" : { },
+      "config" : {
+        "kid" : [ "594014e3-b250-4e0f-9121-0fddb848ed17" ],
+        "secret" : [ "VMudnlo-vTW7Ld1Cw0ksJQEQyzzZ14FlbecEZJ2W3TGknLk04Q15Lo7eBKlVxW3iCItDKFYt0w6_t5i8ALvgcw" ],
+        "priority" : [ "100" ],
+        "algorithm" : [ "HS256" ]
+      }
+    } ]
+  },
+  "internationalizationEnabled" : false,
+  "supportedLocales" : [ ],
+  "authenticationFlows" : [ {
+    "id" : "c1028e3f-9455-4c7c-b0cd-7233e7471ae5",
+    "alias" : "Account verification options",
+    "description" : "Method with which to verity the existing account",
+    "providerId" : "basic-flow",
+    "topLevel" : false,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "idp-email-verification",
+      "requirement" : "ALTERNATIVE",
+      "priority" : 10,
+      "userSetupAllowed" : false,
+      "autheticatorFlow" : false
+    }, {
+      "requirement" : "ALTERNATIVE",
+      "priority" : 20,
+      "flowAlias" : "Verify Existing Account by Re-authentication",
+      "userSetupAllowed" : false,
+      "autheticatorFlow" : true
+    } ]
+  }, {
+    "id" : "2b03f917-6530-4913-a71f-053f7bd4ae2f",
+    "alias" : "Authentication Options",
+    "description" : "Authentication options.",
+    "providerId" : "basic-flow",
+    "topLevel" : false,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "basic-auth",
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "userSetupAllowed" : false,
+      "autheticatorFlow" : false
+    }, {
+      "authenticator" : "basic-auth-otp",
+      "requirement" : "DISABLED",
+      "priority" : 20,
+      "userSetupAllowed" : false,
+      "autheticatorFlow" : false
+    }, {
+      "authenticator" : "auth-spnego",
+      "requirement" : "DISABLED",
+      "priority" : 30,
+      "userSetupAllowed" : false,
+      "autheticatorFlow" : false
+    } ]
+  }, {
+    "id" : "0deb4bbb-d2ae-408c-b98a-86cc4fb46f8a",
+    "alias" : "Browser - Conditional OTP",
+    "description" : "Flow to determine if the OTP is required for the authentication",
+    "providerId" : "basic-flow",
+    "topLevel" : false,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "conditional-user-configured",
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "userSetupAllowed" : false,
+      "autheticatorFlow" : false
+    }, {
+      "authenticator" : "auth-otp-form",
+      "requirement" : "REQUIRED",
+      "priority" : 20,
+      "userSetupAllowed" : false,
+      "autheticatorFlow" : false
+    } ]
+  }, {
+    "id" : "69f46e30-2108-4d5a-b378-cde304975b61",
+    "alias" : "Direct Grant - Conditional OTP",
+    "description" : "Flow to determine if the OTP is required for the authentication",
+    "providerId" : "basic-flow",
+    "topLevel" : false,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "conditional-user-configured",
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "userSetupAllowed" : false,
+      "autheticatorFlow" : false
+    }, {
+      "authenticator" : "direct-grant-validate-otp",
+      "requirement" : "REQUIRED",
+      "priority" : 20,
+      "userSetupAllowed" : false,
+      "autheticatorFlow" : false
+    } ]
+  }, {
+    "id" : "90a92925-ed66-429a-a3e6-0301fd546436",
+    "alias" : "First broker login - Conditional OTP",
+    "description" : "Flow to determine if the OTP is required for the authentication",
+    "providerId" : "basic-flow",
+    "topLevel" : false,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "conditional-user-configured",
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "userSetupAllowed" : false,
+      "autheticatorFlow" : false
+    }, {
+      "authenticator" : "auth-otp-form",
+      "requirement" : "REQUIRED",
+      "priority" : 20,
+      "userSetupAllowed" : false,
+      "autheticatorFlow" : false
+    } ]
+  }, {
+    "id" : "3c08975a-fe7b-4643-9b14-e00a56e38828",
+    "alias" : "Handle Existing Account",
+    "description" : "Handle what to do if there is existing account with same email/username like authenticated identity provider",
+    "providerId" : "basic-flow",
+    "topLevel" : false,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "idp-confirm-link",
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "userSetupAllowed" : false,
+      "autheticatorFlow" : false
+    }, {
+      "requirement" : "REQUIRED",
+      "priority" : 20,
+      "flowAlias" : "Account verification options",
+      "userSetupAllowed" : false,
+      "autheticatorFlow" : true
+    } ]
+  }, {
+    "id" : "b4f81b41-74b3-47d0-8803-ab183b47c539",
+    "alias" : "Reset - Conditional OTP",
+    "description" : "Flow to determine if the OTP should be reset or not. Set to REQUIRED to force.",
+    "providerId" : "basic-flow",
+    "topLevel" : false,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "conditional-user-configured",
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "userSetupAllowed" : false,
+      "autheticatorFlow" : false
+    }, {
+      "authenticator" : "reset-otp",
+      "requirement" : "REQUIRED",
+      "priority" : 20,
+      "userSetupAllowed" : false,
+      "autheticatorFlow" : false
+    } ]
+  }, {
+    "id" : "eb4e9e15-79ba-4bc1-a061-3649539f638f",
+    "alias" : "User creation or linking",
+    "description" : "Flow for the existing/non-existing user alternatives",
+    "providerId" : "basic-flow",
+    "topLevel" : false,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticatorConfig" : "create unique user config",
+      "authenticator" : "idp-create-user-if-unique",
+      "requirement" : "ALTERNATIVE",
+      "priority" : 10,
+      "userSetupAllowed" : false,
+      "autheticatorFlow" : false
+    }, {
+      "requirement" : "ALTERNATIVE",
+      "priority" : 20,
+      "flowAlias" : "Handle Existing Account",
+      "userSetupAllowed" : false,
+      "autheticatorFlow" : true
+    } ]
+  }, {
+    "id" : "83bf6473-f98c-4b31-9ea9-4094129d9dac",
+    "alias" : "Verify Existing Account by Re-authentication",
+    "description" : "Reauthentication of existing account",
+    "providerId" : "basic-flow",
+    "topLevel" : false,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "idp-username-password-form",
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "userSetupAllowed" : false,
+      "autheticatorFlow" : false
+    }, {
+      "requirement" : "CONDITIONAL",
+      "priority" : 20,
+      "flowAlias" : "First broker login - Conditional OTP",
+      "userSetupAllowed" : false,
+      "autheticatorFlow" : true
+    } ]
+  }, {
+    "id" : "c8da855d-e952-43b6-82ac-7f9010da9268",
+    "alias" : "browser",
+    "description" : "browser based authentication",
+    "providerId" : "basic-flow",
+    "topLevel" : true,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "auth-cookie",
+      "requirement" : "ALTERNATIVE",
+      "priority" : 10,
+      "userSetupAllowed" : false,
+      "autheticatorFlow" : false
+    }, {
+      "authenticator" : "auth-spnego",
+      "requirement" : "DISABLED",
+      "priority" : 20,
+      "userSetupAllowed" : false,
+      "autheticatorFlow" : false
+    }, {
+      "authenticator" : "identity-provider-redirector",
+      "requirement" : "ALTERNATIVE",
+      "priority" : 25,
+      "userSetupAllowed" : false,
+      "autheticatorFlow" : false
+    }, {
+      "requirement" : "ALTERNATIVE",
+      "priority" : 30,
+      "flowAlias" : "forms",
+      "userSetupAllowed" : false,
+      "autheticatorFlow" : true
+    } ]
+  }, {
+    "id" : "76df3bf7-bf4e-4749-a52b-85bca26e84a9",
+    "alias" : "clients",
+    "description" : "Base authentication for clients",
+    "providerId" : "client-flow",
+    "topLevel" : true,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "client-secret",
+      "requirement" : "ALTERNATIVE",
+      "priority" : 10,
+      "userSetupAllowed" : false,
+      "autheticatorFlow" : false
+    }, {
+      "authenticator" : "client-jwt",
+      "requirement" : "ALTERNATIVE",
+      "priority" : 20,
+      "userSetupAllowed" : false,
+      "autheticatorFlow" : false
+    }, {
+      "authenticator" : "client-secret-jwt",
+      "requirement" : "ALTERNATIVE",
+      "priority" : 30,
+      "userSetupAllowed" : false,
+      "autheticatorFlow" : false
+    }, {
+      "authenticator" : "client-x509",
+      "requirement" : "ALTERNATIVE",
+      "priority" : 40,
+      "userSetupAllowed" : false,
+      "autheticatorFlow" : false
+    } ]
+  }, {
+    "id" : "2b5b5f37-f39c-49be-8a3b-2af598e70a65",
+    "alias" : "direct grant",
+    "description" : "OpenID Connect Resource Owner Grant",
+    "providerId" : "basic-flow",
+    "topLevel" : true,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "direct-grant-validate-username",
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "userSetupAllowed" : false,
+      "autheticatorFlow" : false
+    }, {
+      "authenticator" : "direct-grant-validate-password",
+      "requirement" : "REQUIRED",
+      "priority" : 20,
+      "userSetupAllowed" : false,
+      "autheticatorFlow" : false
+    }, {
+      "requirement" : "CONDITIONAL",
+      "priority" : 30,
+      "flowAlias" : "Direct Grant - Conditional OTP",
+      "userSetupAllowed" : false,
+      "autheticatorFlow" : true
+    } ]
+  }, {
+    "id" : "119b7a4a-b085-4d68-919f-5fde44d5e4f2",
+    "alias" : "docker auth",
+    "description" : "Used by Docker clients to authenticate against the IDP",
+    "providerId" : "basic-flow",
+    "topLevel" : true,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "docker-http-basic-authenticator",
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "userSetupAllowed" : false,
+      "autheticatorFlow" : false
+    } ]
+  }, {
+    "id" : "76fbd7ed-aa77-49e4-9e66-a9dd966c755e",
+    "alias" : "first broker login",
+    "description" : "Actions taken after first broker login with identity provider account, which is not yet linked to any Keycloak account",
+    "providerId" : "basic-flow",
+    "topLevel" : true,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticatorConfig" : "review profile config",
+      "authenticator" : "idp-review-profile",
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "userSetupAllowed" : false,
+      "autheticatorFlow" : false
+    }, {
+      "requirement" : "REQUIRED",
+      "priority" : 20,
+      "flowAlias" : "User creation or linking",
+      "userSetupAllowed" : false,
+      "autheticatorFlow" : true
+    } ]
+  }, {
+    "id" : "88847049-35ce-4515-bec3-0d306517d2a0",
+    "alias" : "forms",
+    "description" : "Username, password, otp and other auth forms.",
+    "providerId" : "basic-flow",
+    "topLevel" : false,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "auth-username-password-form",
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "userSetupAllowed" : false,
+      "autheticatorFlow" : false
+    }, {
+      "requirement" : "CONDITIONAL",
+      "priority" : 20,
+      "flowAlias" : "Browser - Conditional OTP",
+      "userSetupAllowed" : false,
+      "autheticatorFlow" : true
+    } ]
+  }, {
+    "id" : "fdaf9ea6-e32e-4a2b-be03-1e6416c87b42",
+    "alias" : "http challenge",
+    "description" : "An authentication flow based on challenge-response HTTP Authentication Schemes",
+    "providerId" : "basic-flow",
+    "topLevel" : true,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "no-cookie-redirect",
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "userSetupAllowed" : false,
+      "autheticatorFlow" : false
+    }, {
+      "requirement" : "REQUIRED",
+      "priority" : 20,
+      "flowAlias" : "Authentication Options",
+      "userSetupAllowed" : false,
+      "autheticatorFlow" : true
+    } ]
+  }, {
+    "id" : "4086c145-7d3b-4d0f-9d59-f3535008e9a1",
+    "alias" : "registration",
+    "description" : "registration flow",
+    "providerId" : "basic-flow",
+    "topLevel" : true,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "registration-page-form",
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "flowAlias" : "registration form",
+      "userSetupAllowed" : false,
+      "autheticatorFlow" : true
+    } ]
+  }, {
+    "id" : "4f6d876b-c4d9-4dfa-98d8-7f083a984617",
+    "alias" : "registration form",
+    "description" : "registration form",
+    "providerId" : "form-flow",
+    "topLevel" : false,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "registration-user-creation",
+      "requirement" : "REQUIRED",
+      "priority" : 20,
+      "userSetupAllowed" : false,
+      "autheticatorFlow" : false
+    }, {
+      "authenticator" : "registration-profile-action",
+      "requirement" : "REQUIRED",
+      "priority" : 40,
+      "userSetupAllowed" : false,
+      "autheticatorFlow" : false
+    }, {
+      "authenticator" : "registration-password-action",
+      "requirement" : "REQUIRED",
+      "priority" : 50,
+      "userSetupAllowed" : false,
+      "autheticatorFlow" : false
+    }, {
+      "authenticator" : "registration-recaptcha-action",
+      "requirement" : "DISABLED",
+      "priority" : 60,
+      "userSetupAllowed" : false,
+      "autheticatorFlow" : false
+    } ]
+  }, {
+    "id" : "33fddd29-14ae-4e46-9733-183a771316e3",
+    "alias" : "reset credentials",
+    "description" : "Reset credentials for a user if they forgot their password or something",
+    "providerId" : "basic-flow",
+    "topLevel" : true,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "reset-credentials-choose-user",
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "userSetupAllowed" : false,
+      "autheticatorFlow" : false
+    }, {
+      "authenticator" : "reset-credential-email",
+      "requirement" : "REQUIRED",
+      "priority" : 20,
+      "userSetupAllowed" : false,
+      "autheticatorFlow" : false
+    }, {
+      "authenticator" : "reset-password",
+      "requirement" : "REQUIRED",
+      "priority" : 30,
+      "userSetupAllowed" : false,
+      "autheticatorFlow" : false
+    }, {
+      "requirement" : "CONDITIONAL",
+      "priority" : 40,
+      "flowAlias" : "Reset - Conditional OTP",
+      "userSetupAllowed" : false,
+      "autheticatorFlow" : true
+    } ]
+  }, {
+    "id" : "2300ab9d-ef2c-4a08-a1a3-3706ef6c8557",
+    "alias" : "saml ecp",
+    "description" : "SAML ECP Profile Authentication Flow",
+    "providerId" : "basic-flow",
+    "topLevel" : true,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "http-basic-authenticator",
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "userSetupAllowed" : false,
+      "autheticatorFlow" : false
+    } ]
+  } ],
+  "authenticatorConfig" : [ {
+    "id" : "c5c6a65e-521d-4c40-8777-0dd84344fe0c",
+    "alias" : "create unique user config",
+    "config" : {
+      "require.password.update.after.registration" : "false"
+    }
+  }, {
+    "id" : "a91b3e6e-e4b7-445d-95fd-eca1cecf8691",
+    "alias" : "review profile config",
+    "config" : {
+      "update.profile.on.first.login" : "missing"
+    }
+  } ],
+  "requiredActions" : [ {
+    "alias" : "CONFIGURE_TOTP",
+    "name" : "Configure OTP",
+    "providerId" : "CONFIGURE_TOTP",
+    "enabled" : true,
+    "defaultAction" : false,
+    "priority" : 10,
+    "config" : { }
+  }, {
+    "alias" : "terms_and_conditions",
+    "name" : "Terms and Conditions",
+    "providerId" : "terms_and_conditions",
+    "enabled" : false,
+    "defaultAction" : false,
+    "priority" : 20,
+    "config" : { }
+  }, {
+    "alias" : "UPDATE_PASSWORD",
+    "name" : "Update Password",
+    "providerId" : "UPDATE_PASSWORD",
+    "enabled" : true,
+    "defaultAction" : false,
+    "priority" : 30,
+    "config" : { }
+  }, {
+    "alias" : "UPDATE_PROFILE",
+    "name" : "Update Profile",
+    "providerId" : "UPDATE_PROFILE",
+    "enabled" : true,
+    "defaultAction" : false,
+    "priority" : 40,
+    "config" : { }
+  }, {
+    "alias" : "VERIFY_EMAIL",
+    "name" : "Verify Email",
+    "providerId" : "VERIFY_EMAIL",
+    "enabled" : true,
+    "defaultAction" : false,
+    "priority" : 50,
+    "config" : { }
+  }, {
+    "alias" : "update_user_locale",
+    "name" : "Update User Locale",
+    "providerId" : "update_user_locale",
+    "enabled" : true,
+    "defaultAction" : false,
+    "priority" : 1000,
+    "config" : { }
+  } ],
+  "browserFlow" : "browser",
+  "registrationFlow" : "registration",
+  "directGrantFlow" : "direct grant",
+  "resetCredentialsFlow" : "reset credentials",
+  "clientAuthenticationFlow" : "clients",
+  "dockerAuthenticationFlow" : "docker auth",
+  "attributes" : { },
+  "keycloakVersion" : "9.0.3",
+  "userManagedAccessAllowed" : false
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dsb-norge/vue-keycloak-js",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "author": "Nils Lien <nils.lien@gmail.com>",
   "description": "A Keycloak plugin for Vue >= 2.x",
   "main": "dist/dsb-vue-keycloak.cjs.js",

--- a/src/index.js
+++ b/src/index.js
@@ -88,9 +88,14 @@ function init (config, watch, options) {
     updateWatchVariables(false)
     typeof options.onAuthRefreshError === 'function' && options.onAuthRefreshError(keycloak)
   }
-  keycloak.init(options.init)
-  .catch(err => {
-    typeof options.onInitError === 'function' && options.onInitError(err)
+  keycloak.init(options.init).then((authenticated) => {
+    updateWatchVariables(authenticated)
+    typeof options.onInitSuccess === 'function' && options.onInitSuccess(authenticated)
+  }).catch(() => {
+    // Keycloak does not return any error message
+    updateWatchVariables(false)
+    const error = Error('Could not initialized keycloak-js adapter')
+    typeof options.onInitError === 'function' ? options.onInitError(error) : console.error(error)
   })
 
   function updateWatchVariables (isAuthenticated = false) {

--- a/src/index.js
+++ b/src/index.js
@@ -9,58 +9,55 @@ export default {
 
     const defaultParams = {
       config: window.__BASEURL__ ? `${window.__BASEURL__}/config` : '/config',
-      init: {onLoad: 'login-required'}
+      init: { onLoad: 'login-required' }
     }
     const options = Object.assign({}, defaultParams, params)
     if (assertOptions(options).hasError) throw new Error(`Invalid options given: ${assertOptions(options).error}`)
 
-    const watch = new Vue({
-      data () {
-        return {
-          ready: false,
-          authenticated: false,
-          userName: null,
-          fullName: null,
-          token: null,
-          tokenParsed: null,
-          logoutFn: null,
-          loginFn: null,
-          login: null,
-          createLoginUrl: null,
-          createLogoutUrl: null,
-          createRegisterUrl: null,
-          register: null,
-          accountManagement: null,
-          createAccountUrl: null,
-          loadUserProfile: null,
-          loadUserInfo: null,
-          subject: null,
-          idToken: null,
-          idTokenParsed: null,
-          realmAccess: null,
-          resourceAccess: null,
-          refreshToken: null,
-          refreshTokenParsed: null,
-          timeSkew: null,
-          responseMode: null,
-          responseType: null,
-          hasRealmRole: null,
-          hasResourceRole: null
-        }
+    const watch = Vue.observable({
+      ready: false,
+      authenticated: false,
+      userName: null,
+      fullName: null,
+      token: null,
+      tokenParsed: null,
+      logoutFn: null,
+      loginFn: null,
+      login: null,
+      createLoginUrl: null,
+      createLogoutUrl: null,
+      createRegisterUrl: null,
+      register: null,
+      accountManagement: null,
+      createAccountUrl: null,
+      loadUserProfile: null,
+      loadUserInfo: null,
+      subject: null,
+      idToken: null,
+      idTokenParsed: null,
+      realmAccess: null,
+      resourceAccess: null,
+      refreshToken: null,
+      refreshTokenParsed: null,
+      timeSkew: null,
+      responseMode: null,
+      responseType: null,
+      hasRealmRole: null,
+      hasResourceRole: null,
+      keycloak: null
+    })
+    Object.defineProperty(Vue.prototype, '$keycloak', {
+      get () {
+        return watch
       }
     })
     getConfig(options.config)
-      .then(config => {
-        init(config, watch, options)
-        Object.defineProperty(Vue.prototype, '$keycloak', {
-          get () {
-            return watch
-          }
-        })
-      })
-      .catch(err => {
-        console.log(err)
-      })
+    .then(config => {
+      init(config, watch, options)
+    })
+    .catch(err => {
+      console.log(err)
+    })
   }
 }
 
@@ -68,14 +65,10 @@ function init (config, watch, options) {
   const ctor = sanitizeConfig(config)
   const keycloak = Keycloak(ctor)
 
-  watch.$once('ready', function (cb) {
-    cb && cb()
-  })
-
   keycloak.onReady = function (authenticated) {
     updateWatchVariables(authenticated)
     watch.ready = true
-    typeof options.onReady === 'function' && watch.$emit('ready', options.onReady.bind(this, keycloak))
+    typeof options.onReady === 'function' && options.onReady(keycloak)
   }
   keycloak.onAuthSuccess = function () {
     // Check token validity every 10 seconds (10 000 ms) and, if necessary, update the token.
@@ -85,7 +78,7 @@ function init (config, watch, options) {
     }), 10000)
     watch.logoutFn = () => {
       clearInterval(updateTokenInterval)
-      keycloak.logout(options.logout || {'redirectUri': config['logoutRedirectUri']})
+      keycloak.logout(options.logout || { 'redirectUri': config['logoutRedirectUri'] })
     }
   }
   keycloak.onAuthRefreshSuccess = function () {
@@ -93,12 +86,12 @@ function init (config, watch, options) {
   }
   keycloak.onAuthRefreshError = function () {
     updateWatchVariables(false)
-    typeof options.onAuthRefreshError === 'function' && options.onAuthRefreshError.bind(this, keycloak)()
+    typeof options.onAuthRefreshError === 'function' && options.onAuthRefreshError(keycloak)
   }
   keycloak.init(options.init)
-    .catch(err => {
-      typeof options.onInitError === 'function' && options.onInitError(err)
-    })
+  .catch(err => {
+    typeof options.onInitError === 'function' && options.onInitError(err)
+  })
 
   function updateWatchVariables (isAuthenticated = false) {
     watch.authenticated = isAuthenticated
@@ -108,6 +101,7 @@ function init (config, watch, options) {
     watch.createLogoutUrl = keycloak.createLogoutUrl
     watch.createRegisterUrl = keycloak.createRegisterUrl
     watch.register = keycloak.register
+    watch.keycloak = keycloak
     if (isAuthenticated) {
       watch.accountManagement = keycloak.accountManagement
       watch.createAccountUrl = keycloak.createAccountUrl
@@ -134,21 +128,21 @@ function init (config, watch, options) {
 }
 
 function assertOptions (options) {
-  const {config, init, onReady, onInitError, onAuthRefreshError} = options
+  const { config, init, onReady, onInitError, onAuthRefreshError } = options
   if (typeof config !== 'string' && !_isObject(config)) {
-    return {hasError: true, error: `'config' option must be a string or an object. Found: '${config}'`}
+    return { hasError: true, error: `'config' option must be a string or an object. Found: '${config}'` }
   }
   if (!_isObject(init) || typeof init.onLoad !== 'string') {
-    return {hasError: true, error: `'init' option must be an object with an 'onLoad' property. Found: '${init}'`}
+    return { hasError: true, error: `'init' option must be an object with an 'onLoad' property. Found: '${init}'` }
   }
   if (onReady && typeof onReady !== 'function') {
-    return {hasError: true, error: `'onReady' option must be a function. Found: '${onReady}'`}
+    return { hasError: true, error: `'onReady' option must be a function. Found: '${onReady}'` }
   }
   if (onInitError && typeof onInitError !== 'function') {
-    return {hasError: true, error: `'onInitError' option must be a function. Found: '${onInitError}'`}
+    return { hasError: true, error: `'onInitError' option must be a function. Found: '${onInitError}'` }
   }
   if (onAuthRefreshError && typeof onAuthRefreshError !== 'function') {
-    return {hasError: true, error: `'onAuthRefreshError' option must be a function. Found: '${onAuthRefreshError}'`}
+    return { hasError: true, error: `'onAuthRefreshError' option must be a function. Found: '${onAuthRefreshError}'` }
   }
   return {
     hasError: false,
@@ -179,8 +173,8 @@ function getConfig (config) {
   })
 }
 
-function sanitizeConfig(config) {
-  const renameProp = (oldProp, newProp, {[oldProp]: old, ...others}) => {
+function sanitizeConfig (config) {
+  const renameProp = (oldProp, newProp, { [oldProp]: old, ...others }) => {
     return {
       [newProp]: old,
       ...others


### PR DESCRIPTION
- The $keycloak property should now get added before config promise is finished.
   Should allow 'check-sso' configurations to load faster and outside onReady callback. And avoid unnecessary "white screen" 
- Exposed all attributes from keycloak-js adapter into the watcher #57 . 
- Watcher is now also an Observable instead of using an entire Vue app.
- Added some "docker functionality" to more easily spin up a keycloak instance for testing purposes