### PR TITLE
Load the @vue/reactivity dependency in another way

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -15,6 +15,7 @@ const globals = {
   '@vue/reactivity': 'Reactivity',
   'keycloak-js': 'Keycloak',
 }
+const inlineDynamicImports = true
 
 // CommonJS (for Node), ES module (for bundlers) and browser-friendly UMD build.
 export default {
@@ -26,7 +27,8 @@ export default {
       format: 'cjs',
       banner,
       name,
-      globals
+      globals,
+      inlineDynamicImports
     },
     {
       exports: 'default',
@@ -34,7 +36,8 @@ export default {
       format: 'es',
       banner,
       name,
-      globals
+      globals,
+      inlineDynamicImports
     },
     {
       exports: 'default',
@@ -42,7 +45,8 @@ export default {
       format: 'umd',
       banner,
       name,
-      globals
+      globals,
+      inlineDynamicImports
     },
   ],
   plugins: [
@@ -59,5 +63,5 @@ export default {
       babelHelpers: 'bundled',
     }),
   ],
-  external: ['vue', '@vue/reactivity', 'keycloak-js'],
+  external: ['vue', 'keycloak-js'],
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,4 @@
 import Keycloak from 'keycloak-js'
-import { reactive } from '@vue/reactivity'
 import type {
   VueKeycloakConfig,
   VueKeycloakOptions,
@@ -24,7 +23,7 @@ export default {
     if (assertOptions(options).hasError)
       throw new Error(`Invalid options given: ${assertOptions(options).error}`)
 
-    const watch = vue2AndVue3Reactive(app, {
+    vue2AndVue3Reactive(app, {
       ready: false,
       authenticated: false,
       userName: null,
@@ -54,18 +53,19 @@ export default {
       hasRealmRole: null,
       hasResourceRole: null,
       keycloak: null,
+    }).then((watch) => {
+      getConfig(options.config)
+        .then((config: VueKeycloakConfig) => {
+          init(config, watch, options)
+        })
+        .catch((err) => {
+          console.log(err)
+        })
     })
-    getConfig(options.config)
-      .then((config: VueKeycloakConfig) => {
-        init(config, watch, options)
-      })
-      .catch((err) => {
-        console.log(err)
-      })
   },
 }
 
-function vue2AndVue3Reactive(app: Vue2Vue3App, object: VueKeycloakInstance) {
+async function vue2AndVue3Reactive(app: Vue2Vue3App, object: VueKeycloakInstance) {
   if (app.prototype) {
     // Vue 2
     const reactiveObj = app.observable(object)
@@ -77,8 +77,14 @@ function vue2AndVue3Reactive(app: Vue2Vue3App, object: VueKeycloakInstance) {
     return reactiveObj
   } else {
     // Vue 3
-    const reactiveObj = reactive(object)
+
+    // Assign an object immediately to allow usage of $keycloak in view
+    const reactiveObj = {}
     app.config.globalProperties.$keycloak = reactiveObj
+    // Async load module to allow vue 2 to not have the dependency.
+    const reactivity = await import ('@vue/reactivity')
+    // Override the existing reactiveObj so references contains the new reactive values
+    Object.assign(reactiveObj, reactivity.reactive(object))
     return reactiveObj
   }
 }


### PR DESCRIPTION
Should now load the @vue/reactivity dependency asynchronously and conditionally allowing vue 2 projects to not have it