### PR TITLE
Update axios tokenInterceptor example in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,7 +228,9 @@ In conjunction with the above, you might find it useful to intercept e.g. axios 
 ```javascript
 function tokenInterceptor () {
   axios.interceptors.request.use(config => {
-    config.headers.Authorization = `Bearer ${Vue.prototype.$keycloak.token}`
+    if (Vue.prototype.$keycloak.authenticated) {
+      config.headers.Authorization = `Bearer ${Vue.prototype.$keycloak.token}`
+    }
     return config
   }, error => {
     return Promise.reject(error)


### PR DESCRIPTION
This change updates the axios tokenInterceptor example to only send the token if keycloak is authenticated.
Therefore when no user is authenticated, no authorization header / token is sent with the request instead of 'Bearer null' (e.g. for publicly available resources with check-sso option).