### PR TITLE
feat: adding autoRefreshToken option.

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -83,7 +83,7 @@ function defaultEmptyVueKeycloakInstance(): VueKeycloakInstance {
 
 async function init(config: VueKeycloakConfig, store: Reactive<VueKeycloakInstance>, options: VueKeycloakOptions) {
   const keycloak = new Keycloak(config)
-  const { updateInterval } = options
+  const { updateInterval, autoRefreshToken = true } = options
 
   function updateWatchVariables(isAuthenticated = false) {
     store.authenticated = isAuthenticated
@@ -126,6 +126,9 @@ async function init(config: VueKeycloakConfig, store: Reactive<VueKeycloakInstan
   }
 
   keycloak.onAuthSuccess = function () {
+    if (!autoRefreshToken) {
+      return;
+    }
     const updateTokenInterval = setInterval(
       () => {
         keycloak.updateToken(60)

--- a/src/types.ts
+++ b/src/types.ts
@@ -29,8 +29,9 @@ export type VueKeycloakConfig = KeycloakConfig | string;
 export interface VueKeycloakOptions {
   config?: VueKeycloakConfig;
   init?: KeycloakInitOptions;
-  logout?: KeycloakLogoutOptions | undefined;
+  logout?: KeycloakLogoutOptions;
   updateInterval?: number;
+  autoRefreshToken?: boolean;
   onReady?: (
     keycloak: Keycloak,
     VueKeycloak?: VueKeycloakInstance


### PR DESCRIPTION
Adding the autoRefreshToken option caters to users who prefer not to auto-refresh the token.

We are using vue-keycloak-js in our SDK, and many of our projects rely on this SDK. While some projects require automatic token refresh, others prefer to refresh the token manually, such as checking and refreshing the token before an AJAX request. To support both scenarios, adding this flag will enhance the plugin's flexibility.

BTW, it would also solve the issue: https://github.com/dsb-norge/vue-keycloak-js/issues/126